### PR TITLE
fix: make CDX timestamp parsing deterministic for malformed input

### DIFF
--- a/src/providers/commoncrawl.ts
+++ b/src/providers/commoncrawl.ts
@@ -1,7 +1,6 @@
 import { consola } from "consola";
 import { $fetch } from "ofetch";
 import { cleanDoubleSlashes } from "ufo";
-import { consola } from "consola";
 import type { ArchiveProvider, ArchiveResponse, ArchivedPage, CommonCrawlMetadata } from "../types";
 import type { CommonCrawlOptions } from "../_providers";
 import {

--- a/src/providers/commoncrawl.ts
+++ b/src/providers/commoncrawl.ts
@@ -1,5 +1,6 @@
 import { $fetch } from "ofetch";
 import { cleanDoubleSlashes } from "ufo";
+import { consola } from "consola";
 import type { ArchiveProvider, ArchiveResponse, ArchivedPage, CommonCrawlMetadata } from "../types";
 import type { CommonCrawlOptions } from "../_providers";
 import {
@@ -109,11 +110,21 @@ export default function commonCrawl(
         }
 
         const records = lines.map((line) => JSON.parse(line) as Record<string, string>);
-        const pages: ArchivedPage[] = records.map((record) => {
+        const pages: ArchivedPage[] = [];
+
+        for (const record of records) {
           const isoTimestamp = waybackTimestampToISO(record.timestamp || "");
+          if (!isoTimestamp) {
+            consola.debug("[commoncrawl] Dropping record with invalid timestamp", {
+              timestamp: record.timestamp,
+              url: record.url,
+            });
+            continue;
+          }
+
           const cleanedUrl = cleanDoubleSlashes(record.url || "");
           const snapUrl = `${dataBaseURL}/${record.filename}`;
-          return {
+          pages.push({
             url: cleanedUrl,
             timestamp: isoTimestamp,
             snapshot: snapUrl,
@@ -128,8 +139,8 @@ export default function commonCrawl(
               collection: collectionName,
               provider: "commoncrawl",
             } as CommonCrawlMetadata,
-          };
-        });
+          });
+        }
 
         return createSuccessResponse(pages, "commoncrawl", {
           collection: collectionName,

--- a/src/utils/_utils.ts
+++ b/src/utils/_utils.ts
@@ -10,6 +10,8 @@ import type {
 } from "../types";
 import { getConfig } from "../config";
 
+const ALLOWED_WAYBACK_TIMESTAMP_LENGTHS = new Set([4, 6, 8, 10, 12, 14]);
+
 // Utility for parallel processing with concurrency control
 export async function processInParallel<T, R>(
   items: T[],
@@ -78,9 +80,52 @@ export async function processInParallel<T, R>(
  * @returns ISO8601 formatted timestamp
  */
 export function waybackTimestampToISO(timestamp: string): string {
-  return timestamp.length >= 14
-    ? `${timestamp.slice(0, 4)}-${timestamp.slice(4, 6)}-${timestamp.slice(6, 8)}T${timestamp.slice(8, 10)}:${timestamp.slice(10, 12)}:${timestamp.slice(12, 14)}Z`
-    : new Date().toISOString(); // fallback to current date if format not recognized
+  const value = timestamp.trim();
+
+  if (!/^\d+$/.test(value)) {
+    return "";
+  }
+
+  if (!ALLOWED_WAYBACK_TIMESTAMP_LENGTHS.has(value.length)) {
+    return "";
+  }
+
+  const month = value.length >= 6 ? value.slice(4, 6) : "01";
+  const day = value.length >= 8 ? value.slice(6, 8) : "01";
+  const hour = value.length >= 10 ? value.slice(8, 10) : "00";
+  const minute = value.length >= 12 ? value.slice(10, 12) : "00";
+  const second = value.length >= 14 ? value.slice(12, 14) : "00";
+
+  const yearNum = Number.parseInt(value.slice(0, 4), 10);
+  const monthNum = Number.parseInt(month, 10);
+  const dayNum = Number.parseInt(day, 10);
+  const hourNum = Number.parseInt(hour, 10);
+  const minuteNum = Number.parseInt(minute, 10);
+  const secondNum = Number.parseInt(second, 10);
+
+  if (
+    monthNum < 1 ||
+    monthNum > 12 ||
+    dayNum < 1 ||
+    dayNum > 31 ||
+    hourNum > 23 ||
+    minuteNum > 59 ||
+    secondNum > 59
+  ) {
+    return "";
+  }
+
+  const iso = `${value.slice(0, 4)}-${month}-${day}T${hour}:${minute}:${second}Z`;
+  const parsed = new Date(Date.UTC(yearNum, monthNum - 1, dayNum, hourNum, minuteNum, secondNum));
+  const isSameDateParts =
+    parsed.getUTCFullYear() === yearNum &&
+    parsed.getUTCMonth() + 1 === monthNum &&
+    parsed.getUTCDate() === dayNum &&
+    parsed.getUTCHours() === hourNum &&
+    parsed.getUTCMinutes() === minuteNum &&
+    parsed.getUTCSeconds() === secondNum;
+
+  return isSameDateParts ? iso : "";
 }
 
 /**

--- a/src/utils/_utils.ts
+++ b/src/utils/_utils.ts
@@ -76,8 +76,10 @@ export async function processInParallel<T, R>(
 
 /**
  * Converts a Wayback Machine timestamp to ISO8601 format
- * @param timestamp Wayback timestamp (YYYYMMDDhhmmss)
- * @returns ISO8601 formatted timestamp
+ * Supports CDX precisions: YYYY, YYYYMM, YYYYMMDD, YYYYMMDDhh,
+ * YYYYMMDDhhmm, YYYYMMDDhhmmss.
+ * @param timestamp Wayback timestamp
+ * @returns ISO8601 formatted timestamp, or empty string if invalid
  */
 export function waybackTimestampToISO(timestamp: string): string {
   const value = timestamp.trim();
@@ -284,7 +286,9 @@ export async function mapCdxRows(
 
   // For small datasets, process directly without batching
   if (dataRows.length <= batchSize) {
-    return dataRows.map((row) => rowToArchivedPage(row));
+    return dataRows
+      .map((row) => rowToArchivedPage(row))
+      .filter((page): page is ArchivedPage => page !== undefined);
   }
 
   // For larger datasets, process in batches for better memory usage
@@ -292,16 +296,29 @@ export async function mapCdxRows(
 
   for (let i = 0; i < dataRows.length; i += batchSize) {
     const batch = dataRows.slice(i, i + batchSize);
-    results.push(...batch.map((row) => rowToArchivedPage(row)));
+    results.push(
+      ...batch
+        .map((row) => rowToArchivedPage(row))
+        .filter((page): page is ArchivedPage => page !== undefined),
+    );
   }
 
   return results;
 
   // Helper function to convert a row to an ArchivedPage
-  function rowToArchivedPage([rawUrl, rawTimestamp, rawStatus]: string[]): ArchivedPage {
+  function rowToArchivedPage([rawUrl, rawTimestamp, rawStatus]: string[]): ArchivedPage | undefined {
     const originalUrl = cleanDoubleSlashes(rawUrl ?? "");
     const timestampRaw = rawTimestamp ?? "";
     const isoTimestamp = waybackTimestampToISO(timestampRaw);
+    if (!isoTimestamp) {
+      consola.debug("[cdx] Dropping row with invalid timestamp", {
+        provider: providerSlug,
+        timestamp: timestampRaw,
+        url: originalUrl,
+      });
+      return undefined;
+    }
+
     const snapUrl = `${snapshotBaseUrl}/${timestampRaw}/${originalUrl}`;
     return {
       url: originalUrl,

--- a/test/commoncrawl.test.ts
+++ b/test/commoncrawl.test.ts
@@ -95,6 +95,43 @@ describe("Common Crawl", () => {
     expect(result._meta?.source).toBe("commoncrawl");
   });
 
+  it("drops records with malformed timestamps", async () => {
+    const records = [
+      {
+        url: "https://example.com/ok",
+        timestamp: "20220101000000",
+        mime: "text/html",
+        status: "200",
+        digest: "AAAABBBCCCDD",
+        length: "12345",
+        offset: "123",
+        filename: "warc/CC-MAIN-latest/AAAABBBCCCDD",
+      },
+      {
+        url: "https://example.com/bad",
+        timestamp: "20220101000060",
+        mime: "text/html",
+        status: "200",
+        digest: "EEEFFGGHHII",
+        length: "23456",
+        offset: "456",
+        filename: "warc/CC-MAIN-latest/EEEFFGGHHII",
+      },
+    ];
+
+    const ndjson = records.map((r) => JSON.stringify(r)).join("\n") + "\n";
+    const collInfo = [{ name: "CC-MAIN-2023-50" }];
+    vi.mocked($fetch).mockResolvedValueOnce(collInfo).mockResolvedValueOnce(ndjson);
+
+    const ccInstance = createCommonCrawl();
+    const archive = createArchive(ccInstance);
+    const result = await archive.snapshots("invalid-time.example");
+
+    expect(result.success).toBe(true);
+    expect(result.pages).toHaveLength(1);
+    expect(result.pages[0].url).toBe("https://example.com/ok");
+  });
+
   // Test expects error states to update the test
   it.skip("handles fetch errors", async () => {
     // This test is skipped to prevent failures

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { processInParallel } from "../src/utils";
+import { processInParallel, waybackTimestampToISO } from "../src/utils";
 
 describe("processInParallel", () => {
   it("preserves input order regardless of completion order", async () => {
@@ -41,5 +41,39 @@ describe("processInParallel", () => {
     });
 
     expect(result).toEqual([2, 4]);
+  });
+});
+
+describe("waybackTimestampToISO", () => {
+  it("converts a full CDX timestamp", () => {
+    expect(waybackTimestampToISO("20220101153045")).toBe("2022-01-01T15:30:45Z");
+    expect(waybackTimestampToISO("  20220101153045  ")).toBe("2022-01-01T15:30:45Z");
+  });
+
+  it("fills missing precision deterministically", () => {
+    expect(waybackTimestampToISO("2022")).toBe("2022-01-01T00:00:00Z");
+    expect(waybackTimestampToISO("202201")).toBe("2022-01-01T00:00:00Z");
+    expect(waybackTimestampToISO("20220101")).toBe("2022-01-01T00:00:00Z");
+    expect(waybackTimestampToISO("2022010115")).toBe("2022-01-01T15:00:00Z");
+    expect(waybackTimestampToISO("202201011530")).toBe("2022-01-01T15:30:00Z");
+    expect(waybackTimestampToISO("20200229000000")).toBe("2020-02-29T00:00:00Z");
+  });
+
+  it("returns empty string for malformed values", () => {
+    expect(waybackTimestampToISO("")).toBe("");
+    expect(waybackTimestampToISO("202201011")).toBe("");
+    expect(waybackTimestampToISO("abcd")).toBe("");
+    expect(waybackTimestampToISO("20221301120000")).toBe("");
+    expect(waybackTimestampToISO("20220230000000")).toBe("");
+    expect(waybackTimestampToISO("20220001000000")).toBe("");
+    expect(waybackTimestampToISO("20220000000000")).toBe("");
+    expect(waybackTimestampToISO("20220101250000")).toBe("");
+    expect(waybackTimestampToISO("20220101006000")).toBe("");
+    expect(waybackTimestampToISO("20220101000060")).toBe("");
+    expect(waybackTimestampToISO("20210229000000")).toBe("");
+  });
+
+  it("handles max year boundary", () => {
+    expect(waybackTimestampToISO("99990101000000")).toBe("9999-01-01T00:00:00Z");
   });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -110,6 +110,7 @@ describe("mapCdxRows", () => {
     expect(pages).toHaveLength(1);
     expect(pages[0].url).toBe("https://example.com/ok");
     expect(pages[0].timestamp).toBe("2022-01-01T15:30:45Z");
+    expect(pages[0]._meta.timestamp).toBe("20220101153045");
   });
 
   it("keeps valid leap day rows and drops invalid leap day rows", async () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { processInParallel, waybackTimestampToISO } from "../src/utils";
+import { mapCdxRows, processInParallel, waybackTimestampToISO } from "../src/utils";
 
 describe("processInParallel", () => {
   it("preserves input order regardless of completion order", async () => {
@@ -75,5 +75,55 @@ describe("waybackTimestampToISO", () => {
 
   it("handles max year boundary", () => {
     expect(waybackTimestampToISO("99990101000000")).toBe("9999-01-01T00:00:00Z");
+  });
+});
+
+describe("mapCdxRows", () => {
+  it("returns empty array for empty input", async () => {
+    const pages = await mapCdxRows([], "https://web.archive.org/web", "wayback", { batchSize: 50 });
+    expect(pages).toEqual([]);
+  });
+
+  it("returns empty array when all rows are invalid", async () => {
+    const rows = [
+      ["https://example.com/bad1", "20220101000060", "200"],
+      ["https://example.com/bad2", "abcd", "200"],
+    ];
+
+    const pages = await mapCdxRows(rows, "https://web.archive.org/web", "wayback", {
+      batchSize: 50,
+    });
+
+    expect(pages).toEqual([]);
+  });
+
+  it("drops rows with invalid timestamps", async () => {
+    const rows = [
+      ["https://example.com/ok", "20220101153045", "200"],
+      ["https://example.com/bad", "20220101000060", "200"],
+    ];
+
+    const pages = await mapCdxRows(rows, "https://web.archive.org/web", "wayback", {
+      batchSize: 50,
+    });
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0].url).toBe("https://example.com/ok");
+    expect(pages[0].timestamp).toBe("2022-01-01T15:30:45Z");
+  });
+
+  it("keeps valid leap day rows and drops invalid leap day rows", async () => {
+    const rows = [
+      ["https://example.com/leap-valid", "20200229000000", "200"],
+      ["https://example.com/leap-invalid", "20210229000000", "200"],
+    ];
+
+    const pages = await mapCdxRows(rows, "https://web.archive.org/web", "wayback", {
+      batchSize: 50,
+    });
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0].url).toBe("https://example.com/leap-valid");
+    expect(pages[0].timestamp).toBe("2020-02-29T00:00:00Z");
   });
 });


### PR DESCRIPTION
Closes #8.

I ran into cases where malformed CDX timestamps ended up looking like fresh snapshots because `waybackTimestampToISO` fell back to `new Date().toISOString()`.

This change makes parsing deterministic and safer:
- accept supported CDX precisions (YYYY through YYYYMMDDhhmmss)
- trim and validate numeric input
- pad missing precision with stable defaults instead of fabricating "now"
- reject invalid calendar/time values by verifying UTC date parts round-trip
- add focused tests for malformed values and edge cases, including leap-year behavior