### PR TITLE
refactor: use classes

### DIFF
--- a/src/archive.ts
+++ b/src/archive.ts
@@ -120,8 +120,13 @@ export class Archive implements ArchiveInterface {
   private resolvedProviders: ArchiveProvider[] | undefined;
 
   constructor(providers: ProviderInput, options?: ArchiveOptions) {
-    this.providersInput = providers;
+    this.providersInput = Array.isArray(providers) ? [...providers] : providers;
     this.options = options;
+    this.resolveProviders = this.resolveProviders.bind(this);
+    this.snapshots = this.snapshots.bind(this);
+    this.getPages = this.getPages.bind(this);
+    this.use = this.use.bind(this);
+    this.useAll = this.useAll.bind(this);
   }
 
   /**
@@ -131,12 +136,12 @@ export class Archive implements ArchiveInterface {
    */
   async resolveProviders(): Promise<ArchiveProvider[]> {
     if (this.resolvedProviders) {
-      return this.resolvedProviders;
+      return [...this.resolvedProviders];
     }
 
     const result = await Promise.resolve(this.providersInput);
-    this.resolvedProviders = Array.isArray(result) ? result : [result];
-    return this.resolvedProviders;
+    this.resolvedProviders = Array.isArray(result) ? [...result] : [result];
+    return [...this.resolvedProviders];
   }
 
   /**
@@ -301,10 +306,9 @@ export class Archive implements ArchiveInterface {
    * // Add another provider later
    * await archive.use(providers.archiveToday())
    *
-   * // Chain calls
-   * await archive
-   *   .use(providers.webcite())
-   *   .use(providers.commoncrawl())
+   * // Await each addition
+   * await archive.use(providers.webcite())
+   * await archive.use(providers.commoncrawl())
    * ```
    */
   async use(provider: ArchiveProvider | Promise<ArchiveProvider>): Promise<ArchiveInterface> {

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -25,9 +25,330 @@ export class UnsupportedOperationError extends Error {
   }
 }
 
+type ProviderInput =
+  | ArchiveProvider
+  | ArchiveProvider[]
+  | Promise<ArchiveProvider>
+  | Promise<ArchiveProvider[]>;
+
+/**
+ * Combine per-provider responses into a single merged ArchiveResponse.
+ *
+ * Merges pages (deduping nothing – duplicates are the caller's filter problem),
+ * joins errors, and propagates the unsupported-operations list into `_meta`.
+ * The combined response is marked `unsupported` only when *every* queried
+ * provider was structurally unsupported.
+ *
+ * @param responses - Array of per-provider responses (possibly mixed success/failure).
+ * @param limit - Optional cap on the number of pages in the merged result.
+ */
+export function combineResults(
+  responses: ArchiveResponse[],
+  limit?: number,
+): ArchiveResponse {
+  const allPages: ArchivedPage[] = [];
+  const errors: string[] = [];
+  const unsupportedProviders: UnsupportedProviderRecord[] = [];
+  let anySuccess = false;
+
+  for (const response of responses) {
+    const providerSlug = response._meta?.provider ?? "unknown";
+    if (response.success) {
+      anySuccess = true;
+      allPages.push(...response.pages);
+    } else if (response.unsupported) {
+      unsupportedProviders.push({
+        provider: providerSlug,
+        reason: response.unsupportedReason ?? "operation not supported",
+      });
+    } else if (response.error) {
+      errors.push(response.error);
+    }
+  }
+
+  // newest first
+  allPages.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+
+  const limitedPages =
+    typeof limit === "number" && Number.isFinite(limit)
+      ? allPages.slice(0, Math.max(0, limit))
+      : allPages;
+
+  const providersList = responses.map((r) => r._meta?.provider || "unknown").filter(Boolean);
+
+  // Combined response is unsupported only when every queried provider was
+  // unsupported and none produced pages or errors.
+  const allUnsupported =
+    responses.length > 0 &&
+    unsupportedProviders.length === responses.length &&
+    !anySuccess &&
+    errors.length === 0;
+
+  return {
+    success: anySuccess,
+    pages: limitedPages,
+    error: anySuccess || allUnsupported ? undefined : errors.join("; ") || undefined,
+    unsupported: allUnsupported || undefined,
+    unsupportedReason: allUnsupported
+      ? unsupportedProviders.map((u) => `${u.provider}: ${u.reason}`).join("; ")
+      : undefined,
+    _meta: {
+      source: "multiple",
+      provider: providersList.join(","),
+      providerCount: providersList.length,
+      errors: errors.length > 0 ? errors : undefined,
+      unsupportedProviders:
+        unsupportedProviders.length > 0 ? unsupportedProviders : undefined,
+    },
+  };
+}
+
+/**
+ * Unified archive client aggregating one or more `ArchiveProvider`s.
+ *
+ * Use `createArchive()` for the functional entry point; the class exists so
+ * consumers preferring OOP can instantiate it directly and subclass it.
+ */
+export class Archive implements ArchiveInterface {
+  /**
+   * Default options applied to every query unless overridden per-request.
+   * Readonly from the outside – mutate by creating a new `Archive` instead.
+   */
+  readonly options?: ArchiveOptions;
+
+  private readonly providersInput: ProviderInput;
+  private resolvedProviders: ArchiveProvider[] | undefined;
+
+  constructor(providers: ProviderInput, options?: ArchiveOptions) {
+    this.providersInput = providers;
+    this.options = options;
+  }
+
+  /**
+   * Force-resolve providers immediately. Normally resolution is deferred
+   * until the first query so `createArchive(providers.all())` stays cheap
+   * even when never called. Public for consumers that want eager init.
+   */
+  async resolveProviders(): Promise<ArchiveProvider[]> {
+    if (this.resolvedProviders) {
+      return this.resolvedProviders;
+    }
+
+    const result = await Promise.resolve(this.providersInput);
+    this.resolvedProviders = Array.isArray(result) ? result : [result];
+    return this.resolvedProviders;
+  }
+
+  /**
+   * Fetch from a single provider, honoring cache and error-normalization.
+   */
+  private async fetchFromProvider(
+    provider: ArchiveProvider,
+    domain: string,
+    requestOptions: ArchiveOptions,
+  ): Promise<ArchiveResponse> {
+    // Try cache first
+    if (requestOptions.cache !== false) {
+      const cached = await getStoredResponse(provider, domain, requestOptions);
+      if (cached) return cached;
+    }
+
+    try {
+      const response = await provider.snapshots(domain, requestOptions);
+
+      // Cache successful responses
+      if (response.success && requestOptions.cache !== false) {
+        await storeResponse(provider, domain, response, requestOptions);
+      }
+
+      return response;
+    } catch (error) {
+      // Return error response if provider fails
+      return {
+        success: false,
+        pages: [],
+        error: error instanceof Error ? error.message : String(error),
+        _meta: {
+          source: provider.name,
+          provider: provider.name,
+          errorDetails: error,
+        },
+      };
+    }
+  }
+
+  /**
+   * Fetch archived snapshots for a domain.
+   * Returns a full response object with pages, metadata, and cache status.
+   *
+   * @param domain - The domain to search for in archive services (e.g., "example.com")
+   * @param listOptions - Request-specific options that override the default options
+   * @returns Promise resolving to ArchiveResponse with pages, metadata and status
+   *
+   * @example
+   * ```js
+   * // Basic usage
+   * const response = await archive.snapshots('example.com')
+   *
+   * // With request-specific options
+   * const response = await archive.snapshots('example.com', {
+   *   limit: 5,
+   *   cache: false // Skip cache for this request
+   * })
+   * ```
+   */
+  async snapshots(domain: string, listOptions?: ArchiveOptions): Promise<ArchiveResponse> {
+    const mergedOptions = await mergeOptions(this.options, listOptions);
+    const providerArray = await this.resolveProviders();
+
+    // For a single provider, use direct approach
+    if (providerArray.length === 1) {
+      return this.fetchFromProvider(providerArray[0], domain, mergedOptions);
+    }
+
+    // For multiple providers, fetch in parallel with concurrency control
+    const responses = await processInParallel(
+      providerArray,
+      (provider) => this.fetchFromProvider(provider, domain, mergedOptions),
+      {
+        concurrency: mergedOptions.concurrency,
+        batchSize: mergedOptions.batchSize,
+      },
+    );
+
+    return combineResults(responses, mergedOptions.limit);
+  }
+
+  /**
+   * Fetch archived pages for a domain, returning only the pages array.
+   * Throws an error if the request fails (unlike snapshots which returns a success flag).
+   *
+   * @param domain - The domain to search for in archive services
+   * @param listOptions - Request-specific options that override the defaults
+   * @returns Promise resolving to array of ArchivedPage objects
+   * @throws Error if the request fails
+   *
+   * @example
+   * ```js
+   * try {
+   *   // Get pages directly
+   *   const pages = await archive.getPages('example.com', { limit: 10 })
+   *
+   *   // Work with pages array
+   *   pages.forEach(page => console.log(page.snapshot))
+   * } catch (error) {
+   *   console.error('Failed to fetch pages:', error.message)
+   * }
+   * ```
+   */
+  async getPages(domain: string, listOptions?: ArchiveOptions): Promise<ArchivedPage[]> {
+    const res = await this.snapshots(domain, listOptions);
+    if (res.success) {
+      return res.pages;
+    }
+
+    // Whole call was structurally unsupported: throw the dedicated subclass.
+    // Synthesize `.providers` from the raw single-provider response when
+    // `combineResults` was bypassed (`_meta.unsupportedProviders` only exists
+    // for multi-provider runs).
+    if (res.unsupported) {
+      const providers =
+        res._meta?.unsupportedProviders ??
+        (res._meta?.provider
+          ? [
+              {
+                provider: res._meta.provider,
+                reason: res.unsupportedReason ?? "operation not supported",
+              },
+            ]
+          : []);
+      throw new UnsupportedOperationError(
+        res.unsupportedReason ?? "operation not supported by any queried provider",
+        providers,
+      );
+    }
+
+    // Mixed runtime error + partial unsupported, or pure runtime error.
+    // Surface both layers in the message so callers see the full picture
+    // even though the throw type is generic Error.
+    const messageParts: string[] = [];
+    if (res.error) messageParts.push(res.error);
+    if (res._meta?.unsupportedProviders?.length) {
+      messageParts.push(
+        "unsupported: " +
+          res._meta.unsupportedProviders
+            .map((u) => `${u.provider} (${u.reason})`)
+            .join(", "),
+      );
+    }
+    throw new Error(
+      messageParts.length > 0 ? messageParts.join("; ") : "Failed to fetch archive snapshots",
+    );
+  }
+
+  /**
+   * Add a new provider to this archive instance.
+   * Allows for dynamically extending the archive with additional providers.
+   *
+   * @param provider - The provider or Promise resolving to a provider to add
+   * @returns The archive instance for method chaining
+   *
+   * @example
+   * ```js
+   * // Create archive with one provider
+   * const archive = createArchive(providers.wayback())
+   *
+   * // Add another provider later
+   * await archive.use(providers.archiveToday())
+   *
+   * // Chain calls
+   * await archive
+   *   .use(providers.webcite())
+   *   .use(providers.commoncrawl())
+   * ```
+   */
+  async use(provider: ArchiveProvider | Promise<ArchiveProvider>): Promise<ArchiveInterface> {
+    const resolvedProvider = await Promise.resolve(provider);
+    const currentProviders = await this.resolveProviders();
+    this.resolvedProviders = [...currentProviders, resolvedProvider];
+    return this;
+  }
+
+  /**
+   * Add multiple providers to this archive instance at once.
+   * More efficient than calling use() multiple times.
+   *
+   * @param newProviders - Array of providers or Promises resolving to providers
+   * @returns The archive instance for method chaining
+   *
+   * @example
+   * ```js
+   * // Create archive with one provider
+   * const archive = createArchive(providers.wayback())
+   *
+   * // Add multiple providers at once
+   * await archive.useAll([
+   *   providers.archiveToday(),
+   *   providers.webcite(),
+   *   providers.commoncrawl()
+   * ])
+   * ```
+   */
+  async useAll(
+    newProviders: (ArchiveProvider | Promise<ArchiveProvider>)[],
+  ): Promise<ArchiveInterface> {
+    const resolvedNewProviders = await Promise.all(newProviders.map((p) => Promise.resolve(p)));
+    const currentProviders = await this.resolveProviders();
+    this.resolvedProviders = [...currentProviders, ...resolvedNewProviders];
+    return this;
+  }
+}
+
 /**
  * Create a unified archive client that wraps one or multiple providers.
  * Supports lazy loading and asynchronous provider initialization.
+ *
+ * Backwards-compatible functional factory; prefer `new Archive(providers, options)`.
  *
  * @param providers - Single provider, array of providers, or Promise(s) resolving to provider(s)
  * @param options - Default options applied to all queries (limit, cache, ttl, concurrency, etc.)
@@ -61,319 +382,5 @@ export function createArchive(
     | Promise<ArchiveProvider[]>,
   options?: ArchiveOptions,
 ): ArchiveInterface {
-  // Storage for resolved providers
-  let resolvedProviders: ArchiveProvider[] | undefined = undefined;
-
-  /**
-   * Resolves and caches the provider promises.
-   * Ensures providers are only resolved once and then cached for future use.
-   *
-   * @returns Promise resolving to array of all initialized providers
-   * @internal
-   */
-  async function getProviders(): Promise<ArchiveProvider[]> {
-    if (resolvedProviders) {
-      return resolvedProviders;
-    }
-
-    const result = await Promise.resolve(providers);
-
-    resolvedProviders = Array.isArray(result) ? result : [result];
-
-    return resolvedProviders;
-  }
-
-  /**
-   * Fetches data from a single provider with built-in caching.
-   * Attempts to read from cache first, then falls back to fresh data.
-   *
-   * @param provider - The archive provider to query
-   * @param domain - The domain to search for archives
-   * @param requestOptions - Options for this specific request
-   * @returns Promise resolving to provider's response or error response
-   * @internal
-   */
-  async function fetchFromProvider(
-    provider: ArchiveProvider,
-    domain: string,
-    requestOptions: ArchiveOptions,
-  ): Promise<ArchiveResponse> {
-    // Try cache first
-    if (requestOptions.cache !== false) {
-      const cached = await getStoredResponse(provider, domain, requestOptions);
-      if (cached) return cached;
-    }
-
-    try {
-      // Fetch fresh data
-      const response = await provider.snapshots(domain, requestOptions);
-
-      // Cache successful responses
-      if (response.success && requestOptions.cache !== false) {
-        await storeResponse(provider, domain, response, requestOptions);
-      }
-
-      return response;
-    } catch (error) {
-      // Return error response if provider fails
-      return {
-        success: false,
-        pages: [],
-        error: error instanceof Error ? error.message : String(error),
-        _meta: {
-          source: provider.name,
-          provider: provider.name,
-          errorDetails: error,
-        },
-      };
-    }
-  }
-
-  /**
-   * Combines results from multiple providers into a single response.
-   * Merges pages, handles errors, applies sorting and pagination.
-   *
-   * @param responses - Array of responses from different providers
-   * @param limit - Optional limit on number of pages to return
-   * @returns Combined archive response with merged pages and metadata
-   * @internal
-   */
-  function combineResults(responses: ArchiveResponse[], limit?: number): ArchiveResponse {
-    const allPages: ArchivedPage[] = [];
-    const errors: string[] = [];
-    const unsupportedProviders: UnsupportedProviderRecord[] = [];
-    let anySuccess = false;
-
-    for (const response of responses) {
-      const providerSlug = response._meta?.provider ?? "unknown";
-      if (response.success) {
-        anySuccess = true;
-        allPages.push(...response.pages);
-      } else if (response.unsupported) {
-        unsupportedProviders.push({
-          provider: providerSlug,
-          reason: response.unsupportedReason ?? "operation not supported",
-        });
-      } else if (response.error) {
-        errors.push(response.error);
-      }
-    }
-
-    // newest first
-    allPages.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
-
-    const limitedPages =
-      typeof limit === "number" && Number.isFinite(limit)
-        ? allPages.slice(0, Math.max(0, limit))
-        : allPages;
-
-    const providersList = responses.map((r) => r._meta?.provider || "unknown").filter(Boolean);
-
-    // Combined response is unsupported only when every queried provider was
-    // unsupported and none produced pages or errors.
-    const allUnsupported =
-      responses.length > 0 &&
-      unsupportedProviders.length === responses.length &&
-      !anySuccess &&
-      errors.length === 0;
-
-    return {
-      success: anySuccess,
-      pages: limitedPages,
-      error: anySuccess || allUnsupported ? undefined : errors.join("; ") || undefined,
-      unsupported: allUnsupported || undefined,
-      unsupportedReason: allUnsupported
-        ? unsupportedProviders.map((u) => `${u.provider}: ${u.reason}`).join("; ")
-        : undefined,
-      _meta: {
-        source: "multiple",
-        provider: providersList.join(","),
-        providerCount: providersList.length,
-        errors: errors.length > 0 ? errors : undefined,
-        unsupportedProviders:
-          unsupportedProviders.length > 0 ? unsupportedProviders : undefined,
-      },
-    };
-  }
-
-  // Create the archive instance
-  const archive: ArchiveInterface = {
-    // Store options for external access
-    options,
-
-    /**
-     * Fetch archived snapshots for a domain.
-     * Returns a full response object with pages, metadata, and cache status.
-     *
-     * @param domain - The domain to search for in archive services (e.g., "example.com")
-     * @param listOptions - Request-specific options that override the default options
-     * @returns Promise resolving to ArchiveResponse with pages, metadata and status
-     *
-     * @example
-     * ```js
-     * // Basic usage
-     * const response = await archive.snapshots('example.com')
-     *
-     * // With request-specific options
-     * const response = await archive.snapshots('example.com', {
-     *   limit: 5,
-     *   cache: false // Skip cache for this request
-     * })
-     * ```
-     */
-    async snapshots(domain: string, listOptions?: ArchiveOptions): Promise<ArchiveResponse> {
-      const mergedOptions = await mergeOptions(options, listOptions);
-      const providerArray = await getProviders();
-
-      // For a single provider, use direct approach
-      if (providerArray.length === 1) {
-        return fetchFromProvider(providerArray[0], domain, mergedOptions);
-      }
-
-      // For multiple providers, fetch in parallel with concurrency control
-      const responses = await processInParallel(
-        providerArray,
-        (provider) => fetchFromProvider(provider, domain, mergedOptions),
-        {
-          concurrency: mergedOptions.concurrency,
-          batchSize: mergedOptions.batchSize,
-        },
-      );
-
-      return combineResults(responses, mergedOptions.limit);
-    },
-
-    /**
-     * Fetch archived pages for a domain, returning only the pages array.
-     * Throws an error if the request fails (unlike snapshots which returns a success flag).
-     *
-     * @param domain - The domain to search for in archive services
-     * @param listOptions - Request-specific options that override the defaults
-     * @returns Promise resolving to array of ArchivedPage objects
-     * @throws Error if the request fails
-     *
-     * @example
-     * ```js
-     * try {
-     *   // Get pages directly
-     *   const pages = await archive.getPages('example.com', { limit: 10 })
-     *
-     *   // Work with pages array
-     *   pages.forEach(page => console.log(page.snapshot))
-     * } catch (error) {
-     *   console.error('Failed to fetch pages:', error.message)
-     * }
-     * ```
-     */
-    async getPages(domain: string, listOptions?: ArchiveOptions): Promise<ArchivedPage[]> {
-      const res = await this.snapshots(domain, listOptions);
-      if (res.success) {
-        return res.pages;
-      }
-
-      // Whole call was structurally unsupported: throw the dedicated subclass.
-      // Synthesize `.providers` from the raw single-provider response when
-      // `combineResults` was bypassed (`_meta.unsupportedProviders` only exists
-      // for multi-provider runs).
-      if (res.unsupported) {
-        const providers =
-          res._meta?.unsupportedProviders ??
-          (res._meta?.provider
-            ? [
-                {
-                  provider: res._meta.provider,
-                  reason: res.unsupportedReason ?? "operation not supported",
-                },
-              ]
-            : []);
-        throw new UnsupportedOperationError(
-          res.unsupportedReason ?? "operation not supported by any queried provider",
-          providers,
-        );
-      }
-
-      // Mixed runtime error + partial unsupported, or pure runtime error.
-      // Surface both layers in the message so callers see the full picture
-      // even though the throw type is generic Error.
-      const messageParts: string[] = [];
-      if (res.error) messageParts.push(res.error);
-      if (res._meta?.unsupportedProviders?.length) {
-        messageParts.push(
-          "unsupported: " +
-            res._meta.unsupportedProviders
-              .map((u) => `${u.provider} (${u.reason})`)
-              .join(", "),
-        );
-      }
-      throw new Error(
-        messageParts.length > 0 ? messageParts.join("; ") : "Failed to fetch archive snapshots",
-      );
-    },
-
-    /**
-     * Add a new provider to this archive instance.
-     * Allows for dynamically extending the archive with additional providers.
-     *
-     * @param provider - The provider or Promise resolving to a provider to add
-     * @returns The archive instance for method chaining
-     *
-     * @example
-     * ```js
-     * // Create archive with one provider
-     * const archive = createArchive(providers.wayback())
-     *
-     * // Add another provider later
-     * await archive.use(providers.archiveToday())
-     *
-     * // Chain calls
-     * await archive
-     *   .use(providers.webcite())
-     *   .use(providers.commoncrawl())
-     * ```
-     */
-    async use(provider: ArchiveProvider | Promise<ArchiveProvider>): Promise<ArchiveInterface> {
-      const resolvedProvider = await Promise.resolve(provider);
-      const currentProviders = await getProviders();
-
-      // Reset cached providers with the new list
-      resolvedProviders = [...currentProviders, resolvedProvider];
-
-      return this;
-    },
-
-    /**
-     * Add multiple providers to this archive instance at once.
-     * More efficient than calling use() multiple times.
-     *
-     * @param newProviders - Array of providers or Promises resolving to providers
-     * @returns The archive instance for method chaining
-     *
-     * @example
-     * ```js
-     * // Create archive with one provider
-     * const archive = createArchive(providers.wayback())
-     *
-     * // Add multiple providers at once
-     * await archive.useAll([
-     *   providers.archiveToday(),
-     *   providers.webcite(),
-     *   providers.commoncrawl()
-     * ])
-     * ```
-     */
-    async useAll(
-      newProviders: (ArchiveProvider | Promise<ArchiveProvider>)[],
-    ): Promise<ArchiveInterface> {
-      const resolvedNewProviders = await Promise.all(newProviders.map((p) => Promise.resolve(p)));
-
-      const currentProviders = await getProviders();
-
-      // Reset cached providers with the new list
-      resolvedProviders = [...currentProviders, ...resolvedNewProviders];
-
-      return this;
-    },
-  };
-
-  return archive;
+  return new Archive(providers, options);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,11 @@
 export type * from "./types";
-export { createArchive, UnsupportedOperationError } from "./archive";
+export { createArchive, Archive, UnsupportedOperationError, combineResults } from "./archive";
+export { BaseProvider } from "./providers/base-provider";
+export { WaybackProvider } from "./providers/wayback";
+export { ArchiveTodayProvider } from "./providers/archive-today";
+export { PermaccProvider } from "./providers/permacc";
+export { CommonCrawlProvider } from "./providers/commoncrawl";
+export { WebCiteProvider } from "./providers/webcite";
 export { providers } from "./providers";
 export { configureStorage, clearProviderStorage, storage } from "./storage";
 export { getConfig, resolveConfig, resetConfig } from "./config";

--- a/src/providers/archive-today.ts
+++ b/src/providers/archive-today.ts
@@ -1,8 +1,7 @@
+import { consola } from "consola";
 import { $fetch } from "ofetch";
 import { cleanDoubleSlashes } from "ufo";
-import { consola } from "consola";
 import type {
-  ArchiveProvider,
   ArchiveResponse,
   ArchivedPage,
   ArchiveTodayMetadata,
@@ -11,106 +10,101 @@ import type { ArchiveTodayOptions } from "../_providers";
 import {
   createSuccessResponse,
   createErrorResponse,
-  mergeOptions,
   normalizeDomain,
+  stripTrailingSlash,
 } from "../utils";
+import { BaseProvider } from "./base-provider";
 
 /**
- * Create an Archive.today archive provider.
- *
- * @param initOptions - Initial archive options for Archive.today.
- * @returns ArchiveProvider instance for fetching snapshots from Archive.today.
+ * Archive.today archive provider. Uses the Memento timemap endpoint.
  */
-export default function archiveToday(initOptions: ArchiveTodayOptions = {}): ArchiveProvider {
-  return {
-    name: "Archive.today",
-    slug: "archive-today",
+export class ArchiveTodayProvider extends BaseProvider {
+  readonly name = "Archive.today";
+  readonly slug = "archive-today";
 
-    /**
-     * Fetch archived snapshots from Archive.today.
-     *
-     * @param domain - The domain to fetch archives for.
-     * @param reqOptions - Request-specific options overriding initial settings.
-     * @returns Promise resolving to ArchiveResponse containing pages and metadata.
-     */
-    async snapshots(domain: string, reqOptions: ArchiveTodayOptions = {}): Promise<ArchiveResponse> {
-      const cleanDomain = normalizeDomain(domain, false);
+  constructor(readonly options: ArchiveTodayOptions = {}) {
+    super(options);
+  }
 
-      try {
-        const options = await mergeOptions(initOptions, reqOptions);
-        const baseURL = "https://archive.is";
-        // Memento timemap: https://archive.is/timemap/http://example.com
-        const fullUrl = cleanDomain.includes("://") ? cleanDomain : `http://${cleanDomain}`;
-        const timemapUrl = `/timemap/${fullUrl}`;
+  /**
+   * Fetch archived snapshots from Archive.today.
+   */
+  async snapshots(domain: string, reqOptions: ArchiveTodayOptions = {}): Promise<ArchiveResponse> {
+    const cleanDomain = normalizeDomain(domain, false);
 
-        const timemapResponse = await $fetch(timemapUrl, {
-          baseURL,
-          retry: options.retries ?? 5,
-          timeout: options.timeout ?? 60000,
-          responseType: "text",
-        });
+    try {
+      const options = await this.resolveOptions<ArchiveTodayOptions>(reqOptions);
+      const baseURL = "https://archive.is";
+      // Memento timemap: https://archive.is/timemap/http://example.com
+      const fullUrl = cleanDomain.includes("://") ? cleanDomain : `http://${cleanDomain}`;
+      const timemapUrl = `/timemap/${fullUrl}`;
 
-        // Memento link header format:
-        // <http://archive.md/20140101030405/https://example.com/>; rel="memento"; datetime="Wed, 01 Jan 2014 03:04:05 GMT"
-        const pages: ArchivedPage[] = [];
-        const mementoRegex =
-          /<(https?:\/\/archive\.(?:is|today|md|ph)\/([0-9]{8,14})\/(?:https?:\/\/)?([^>]+))>;\s*rel="(?:first\s+)?memento";\s*datetime="([^"]+)"/g;
+      const timemapResponse = await $fetch(timemapUrl, {
+        baseURL,
+        retry: options.retries ?? 5,
+        timeout: options.timeout ?? 60000,
+        responseType: "text",
+      });
 
-        let mementoMatch;
-        let index = 0;
+      // Memento link header format:
+      // <http://archive.md/20140101030405/https://example.com/>; rel="memento"; datetime="Wed, 01 Jan 2014 03:04:05 GMT"
+      const pages: ArchivedPage[] = [];
+      const mementoRegex =
+        /<(https?:\/\/archive\.(?:is|today|md|ph)\/([0-9]{8,14})\/(?:https?:\/\/)?([^>]+))>;\s*rel="(?:first\s+)?memento";\s*datetime="([^"]+)"/g;
 
-        while ((mementoMatch = mementoRegex.exec(timemapResponse)) !== null) {
-          const [, snapshotUrl, timestamp, origUrl, datetime] = mementoMatch;
+      let mementoMatch;
+      let index = 0;
 
-          if (origUrl.includes(cleanDomain)) {
-            try {
-              const parsedDate = new Date(datetime);
-              const isoTimestamp = Number.isNaN(parsedDate.getTime())
-                ? new Date().toISOString()
-                : parsedDate.toISOString();
+      while ((mementoMatch = mementoRegex.exec(timemapResponse)) !== null) {
+        const [, snapshotUrl, timestamp, origUrl, datetime] = mementoMatch;
 
-              let cleanedUrl = cleanDoubleSlashes(
+        if (origUrl.includes(cleanDomain)) {
+          try {
+            const parsedDate = new Date(datetime);
+            const isoTimestamp = Number.isNaN(parsedDate.getTime())
+              ? new Date().toISOString()
+              : parsedDate.toISOString();
+            const cleanedUrl = stripTrailingSlash(
+              cleanDoubleSlashes(
                 origUrl.includes("://") ? origUrl : `https://${origUrl}`,
-              );
-              // strip trailing slash for test compatibility
-              cleanedUrl = cleanedUrl.endsWith("/") ? cleanedUrl.slice(0, -1) : cleanedUrl;
+              ),
+            );
+            const cleanedSnapshotUrl = stripTrailingSlash(snapshotUrl);
 
-              let cleanedSnapshotUrl = snapshotUrl;
-              cleanedSnapshotUrl = cleanedSnapshotUrl.endsWith("/")
-                ? cleanedSnapshotUrl.slice(0, -1)
-                : cleanedSnapshotUrl;
+            pages.push({
+              url: cleanedUrl,
+              timestamp: isoTimestamp,
+              snapshot: cleanedSnapshotUrl,
+              _meta: {
+                hash: timestamp,
+                raw_date: datetime,
+                position: index,
+              } as ArchiveTodayMetadata,
+            });
 
-              pages.push({
-                url: cleanedUrl,
-                timestamp: isoTimestamp,
-                snapshot: cleanedSnapshotUrl,
-                _meta: {
-                  hash: timestamp,
-                  raw_date: datetime,
-                  position: index,
-                } as ArchiveTodayMetadata,
-              });
-
-              index++;
-            } catch (error) {
-              consola.error("Error parsing archive.today snapshot:", error);
-            }
+            index++;
+          } catch (error) {
+            consola.error("Error parsing archive.today snapshot:", error);
           }
         }
-
-        const limitedPages =
-          typeof options.limit === "number" ? pages.slice(0, Math.max(0, options.limit)) : pages;
-
-        return createSuccessResponse(limitedPages, "archive-today", {
-          domain: cleanDomain,
-          page: 1,
-          empty: limitedPages.length === 0,
-        });
-      } catch (error) {
-        return createErrorResponse(error, "archive-today", {
-          domain: cleanDomain,
-        });
       }
-    },
-  };
+
+      const limitedPages =
+        typeof options.limit === "number" ? pages.slice(0, Math.max(0, options.limit)) : pages;
+
+      return createSuccessResponse(limitedPages, "archive-today", {
+        domain: cleanDomain,
+        page: 1,
+        empty: limitedPages.length === 0,
+      });
+    } catch (error) {
+      return createErrorResponse(error, "archive-today", {
+        domain: cleanDomain,
+      });
+    }
+  }
+}
+
+export default function archiveToday(initOptions: ArchiveTodayOptions = {}): ArchiveTodayProvider {
+  return new ArchiveTodayProvider(initOptions);
 }

--- a/src/providers/archive-today.ts
+++ b/src/providers/archive-today.ts
@@ -1,6 +1,6 @@
 import { consola } from "consola";
 import { $fetch } from "ofetch";
-import { cleanDoubleSlashes } from "ufo";
+import { cleanDoubleSlashes, withoutTrailingSlash } from "ufo";
 import type {
   ArchiveResponse,
   ArchivedPage,
@@ -11,20 +11,15 @@ import {
   createSuccessResponse,
   createErrorResponse,
   normalizeDomain,
-  stripTrailingSlash,
 } from "../utils";
 import { BaseProvider } from "./base-provider";
 
 /**
  * Archive.today archive provider. Uses the Memento timemap endpoint.
  */
-export class ArchiveTodayProvider extends BaseProvider {
+export class ArchiveTodayProvider extends BaseProvider<ArchiveTodayOptions> {
   readonly name = "Archive.today";
   readonly slug = "archive-today";
-
-  constructor(readonly options: ArchiveTodayOptions = {}) {
-    super(options);
-  }
 
   /**
    * Fetch archived snapshots from Archive.today.
@@ -33,7 +28,7 @@ export class ArchiveTodayProvider extends BaseProvider {
     const cleanDomain = normalizeDomain(domain, false);
 
     try {
-      const options = await this.resolveOptions<ArchiveTodayOptions>(reqOptions);
+      const options = await this.resolveOptions(reqOptions);
       const baseURL = "https://archive.is";
       // Memento timemap: https://archive.is/timemap/http://example.com
       const fullUrl = cleanDomain.includes("://") ? cleanDomain : `http://${cleanDomain}`;
@@ -64,12 +59,12 @@ export class ArchiveTodayProvider extends BaseProvider {
             const isoTimestamp = Number.isNaN(parsedDate.getTime())
               ? new Date().toISOString()
               : parsedDate.toISOString();
-            const cleanedUrl = stripTrailingSlash(
+            const cleanedUrl = withoutTrailingSlash(
               cleanDoubleSlashes(
                 origUrl.includes("://") ? origUrl : `https://${origUrl}`,
               ),
             );
-            const cleanedSnapshotUrl = stripTrailingSlash(snapshotUrl);
+            const cleanedSnapshotUrl = withoutTrailingSlash(snapshotUrl);
 
             pages.push({
               url: cleanedUrl,

--- a/src/providers/base-provider.ts
+++ b/src/providers/base-provider.ts
@@ -6,22 +6,28 @@ import { mergeOptions } from "../utils";
  * Holds the instance's initial options; concrete providers override
  * `snapshots()` and call `this.resolveOptions(reqOptions)` to get the
  * effective options for a request.
+ *
+ * @template TOptions - Provider-specific options extending the shared archive options.
  */
-export abstract class BaseProvider implements ArchiveProvider {
+export abstract class BaseProvider<TOptions extends ArchiveOptions = ArchiveOptions>
+  implements ArchiveProvider
+{
   abstract readonly name: string;
   abstract readonly slug?: string;
 
-  readonly initOptions: ArchiveOptions;
+  readonly options: Partial<TOptions>;
 
-  constructor(initOptions: ArchiveOptions = {}) {
-    this.initOptions = initOptions;
+  constructor(options: Partial<TOptions> = {}) {
+    this.options = options;
+    this.snapshots = this.snapshots.bind(this);
   }
 
-  protected resolveOptions<T extends ArchiveOptions>(
-    reqOptions: Partial<T> = {},
-  ): Promise<T> {
-    return mergeOptions<T>(this.initOptions as Partial<T>, reqOptions);
+  protected resolveOptions(reqOptions: Partial<TOptions> = {}): Promise<TOptions> {
+    return mergeOptions<TOptions>(this.options, reqOptions);
   }
 
-  abstract snapshots(domain: string, options?: ArchiveOptions): Promise<ArchiveResponse>;
+  abstract snapshots(
+    domain: string,
+    options?: ArchiveOptions,
+  ): Promise<ArchiveResponse>;
 }

--- a/src/providers/base-provider.ts
+++ b/src/providers/base-provider.ts
@@ -1,0 +1,27 @@
+import type { ArchiveOptions, ArchiveProvider, ArchiveResponse } from "../types";
+import { mergeOptions } from "../utils";
+
+/**
+ * Abstract base class for archive providers.
+ * Holds the instance's initial options; concrete providers override
+ * `snapshots()` and call `this.resolveOptions(reqOptions)` to get the
+ * effective options for a request.
+ */
+export abstract class BaseProvider implements ArchiveProvider {
+  abstract readonly name: string;
+  abstract readonly slug?: string;
+
+  readonly initOptions: ArchiveOptions;
+
+  constructor(initOptions: ArchiveOptions = {}) {
+    this.initOptions = initOptions;
+  }
+
+  protected resolveOptions<T extends ArchiveOptions>(
+    reqOptions: Partial<T> = {},
+  ): Promise<T> {
+    return mergeOptions<T>(this.initOptions as Partial<T>, reqOptions);
+  }
+
+  abstract snapshots(domain: string, options?: ArchiveOptions): Promise<ArchiveResponse>;
+}

--- a/src/providers/base-provider.ts
+++ b/src/providers/base-provider.ts
@@ -18,8 +18,10 @@ export abstract class BaseProvider<TOptions extends ArchiveOptions = ArchiveOpti
   readonly options: Partial<TOptions>;
 
   constructor(options: Partial<TOptions> = {}) {
-    this.options = options;
-    this.snapshots = this.snapshots.bind(this);
+    this.options = { ...options };
+    if (typeof this.snapshots === "function") {
+      this.snapshots = this.snapshots.bind(this);
+    }
   }
 
   protected resolveOptions(reqOptions: Partial<TOptions> = {}): Promise<TOptions> {

--- a/src/providers/commoncrawl.ts
+++ b/src/providers/commoncrawl.ts
@@ -1,7 +1,7 @@
 import { consola } from "consola";
 import { $fetch } from "ofetch";
 import { cleanDoubleSlashes } from "ufo";
-import type { ArchiveProvider, ArchiveResponse, ArchivedPage, CommonCrawlMetadata } from "../types";
+import type { ArchiveResponse, ArchivedPage, CommonCrawlMetadata } from "../types";
 import type { CommonCrawlOptions } from "../_providers";
 import {
   waybackTimestampToISO,
@@ -9,163 +9,161 @@ import {
   createSuccessResponse,
   createErrorResponse,
   createFetchOptions,
-  mergeOptions,
 } from "../utils";
-
-function getCollectionCacheKey(
-  initOptions: Partial<CommonCrawlOptions>,
-  requestOptions?: Partial<CommonCrawlOptions>,
-): string | undefined {
-  const collection = requestOptions?.collection ?? initOptions.collection;
-
-  return collection === undefined ? undefined : `collection=${encodeURIComponent(collection)}`;
-}
+import { BaseProvider } from "./base-provider";
 
 /**
- * Create a Common Crawl archive provider.
- *
- * @param initOptions - Initial Common Crawl options (e.g., collection, limit, cache settings).
- * @returns ArchiveProvider instance for fetching snapshots from Common Crawl.
+ * Common Crawl archive provider.
  */
-export default function commonCrawl(
-  initOptions: Partial<CommonCrawlOptions> = {},
-): ArchiveProvider {
-  return {
-    name: "Common Crawl",
-    slug: "commoncrawl",
-    cacheKey: (options) => getCollectionCacheKey(initOptions, options),
+export class CommonCrawlProvider extends BaseProvider {
+  readonly name = "Common Crawl";
+  readonly slug = "commoncrawl";
 
-    /**
-     * Fetch archived snapshots from Common Crawl.
-     *
-     * @param domain - The domain to fetch archives for.
-     * @param reqOptions - Request-specific Common Crawl options (e.g., collection, limit).
-     * @returns Promise resolving to ArchiveResponse containing pages and metadata.
-     */
-    async snapshots(
-      domain: string,
-      reqOptions: Partial<CommonCrawlOptions> = {},
-    ): Promise<ArchiveResponse> {
-      const baseURL = "https://index.commoncrawl.org";
-      const dataBaseURL = "https://data.commoncrawl.org";
-      let collectionName: string | undefined;
+  constructor(readonly options: Partial<CommonCrawlOptions> = {}) {
+    super(options);
+  }
 
-      try {
-        const options = await mergeOptions(initOptions, reqOptions);
+  /**
+   * Cache key extension that separates storage entries by collection.
+   */
+  cacheKey(options?: import("../types").ArchiveOptions): string | undefined {
+    const collection =
+      (options as Partial<CommonCrawlOptions> | undefined)?.collection ?? this.options.collection;
+    return collection === undefined ? undefined : `collection=${encodeURIComponent(collection)}`;
+  }
 
-        // resolve collection: explicit option, or latest via collinfo.json
-        collectionName = options.collection as string | undefined;
-        let indexName: string;
-        if (!collectionName || collectionName === "CC-MAIN-latest") {
-          let apiPath: string | undefined;
-          try {
-            const collinfoOpts = await createFetchOptions(
-              baseURL,
-              {},
-              {
-                retries: options.retries,
-                timeout: options.timeout ?? 60_000,
-              },
-            );
-            interface CollinfoEntry {
-              name?: string;
-              "cdx-api"?: string;
-              cdxApi?: string;
+  /**
+   * Fetch archived snapshots from Common Crawl.
+   */
+  async snapshots(
+    domain: string,
+    reqOptions: Partial<CommonCrawlOptions> = {},
+  ): Promise<ArchiveResponse> {
+    const baseURL = "https://index.commoncrawl.org";
+    const dataBaseURL = "https://data.commoncrawl.org";
+    let collectionName: string | undefined;
+
+    try {
+      const options = await this.resolveOptions<CommonCrawlOptions>(reqOptions);
+
+      // resolve collection: explicit option, or latest via collinfo.json
+      collectionName = options.collection as string | undefined;
+      let indexName: string;
+      if (!collectionName || collectionName === "CC-MAIN-latest") {
+        let apiPath: string | undefined;
+        try {
+          const collinfoOpts = await createFetchOptions(
+            baseURL,
+            {},
+            {
+              retries: options.retries,
+              timeout: options.timeout ?? 60_000,
+            },
+          );
+          interface CollinfoEntry {
+            name?: string;
+            "cdx-api"?: string;
+            cdxApi?: string;
+          }
+          const collinfo = (await $fetch("/collinfo.json", collinfoOpts)) as CollinfoEntry[];
+          if (Array.isArray(collinfo) && collinfo.length > 0) {
+            const first = collinfo[0];
+            const cdxApiProp = first["cdx-api"] || first.cdxApi;
+            if (typeof cdxApiProp === "string") {
+              let raw = cdxApiProp.startsWith("http") ? new URL(cdxApiProp).pathname : cdxApiProp;
+              raw = raw.startsWith("/") ? raw.slice(1) : raw;
+              apiPath = raw;
+              collectionName = raw.endsWith("-index") ? raw.slice(0, -"-index".length) : raw;
+            } else if (typeof first.name === "string") {
+              collectionName = first.name;
+              apiPath = collectionName.endsWith("-index")
+                ? collectionName
+                : `${collectionName}-index`;
             }
-            const collinfo = (await $fetch("/collinfo.json", collinfoOpts)) as CollinfoEntry[];
-            if (Array.isArray(collinfo) && collinfo.length > 0) {
-              const first = collinfo[0];
-              const cdxApiProp = first["cdx-api"] || first.cdxApi;
-              if (typeof cdxApiProp === "string") {
-                let raw = cdxApiProp.startsWith("http") ? new URL(cdxApiProp).pathname : cdxApiProp;
-                raw = raw.startsWith("/") ? raw.slice(1) : raw;
-                apiPath = raw;
-                collectionName = raw.endsWith("-index") ? raw.slice(0, -"-index".length) : raw;
-              } else if (typeof first.name === "string") {
-                collectionName = first.name;
-                apiPath = collectionName.endsWith("-index")
-                  ? collectionName
-                  : `${collectionName}-index`;
-              }
-            }
-          } catch (collinfoError) {
-            consola.debug("[commoncrawl] collinfo.json fetch failed, using fallback:", collinfoError);
           }
-          if (!collectionName) collectionName = "CC-MAIN-latest";
-          if (!apiPath) {
-            apiPath = collectionName.endsWith("-index") ? collectionName : `${collectionName}-index`;
-          }
-          indexName = apiPath;
-        } else {
-          indexName = collectionName.endsWith("-index") ? collectionName : `${collectionName}-index`;
+        } catch (collinfoError) {
+          consola.debug("[commoncrawl] collinfo.json fetch failed, using fallback:", collinfoError);
         }
-
-        const urlPattern = normalizeDomain(domain);
-        const params: Record<string, string> = {
-          url: urlPattern,
-          output: "json",
-          fl: "url,timestamp,status,mime,length,offset,filename,digest",
-          collapse: "digest",
-          limit: String(options.limit ?? 1000),
-        };
-
-        const fetchOptions = await createFetchOptions(baseURL, params, {
-          retries: options.retries,
-          timeout: options.timeout ?? 60_000,
-          responseType: "text",
-        });
-        const raw = await $fetch(`/${indexName}`, fetchOptions);
-        const text = typeof raw === "string" ? raw : String(raw);
-        const lines = text.split("\n").filter((line) => line.trim());
-
-        if (lines.length === 0) {
-          return createSuccessResponse([], "commoncrawl", {
-            collection: collectionName,
-            queryParams: fetchOptions.params,
-          });
+        if (!collectionName) collectionName = "CC-MAIN-latest";
+        if (!apiPath) {
+          apiPath = collectionName.endsWith("-index") ? collectionName : `${collectionName}-index`;
         }
+        indexName = apiPath;
+      } else {
+        indexName = collectionName.endsWith("-index") ? collectionName : `${collectionName}-index`;
+      }
 
-        const records = lines.map((line) => JSON.parse(line) as Record<string, string>);
-        const pages: ArchivedPage[] = [];
+      const urlPattern = normalizeDomain(domain);
+      const params: Record<string, string> = {
+        url: urlPattern,
+        output: "json",
+        fl: "url,timestamp,status,mime,length,offset,filename,digest",
+        collapse: "digest",
+        limit: String(options.limit ?? 1000),
+      };
 
-        for (const record of records) {
-          const isoTimestamp = waybackTimestampToISO(record.timestamp || "");
-          if (!isoTimestamp) {
-            consola.debug("[commoncrawl] Dropping record with invalid timestamp", {
-              timestamp: record.timestamp,
-              url: record.url,
-            });
-            continue;
-          }
+      const fetchOptions = await createFetchOptions(baseURL, params, {
+        retries: options.retries,
+        timeout: options.timeout ?? 60_000,
+        responseType: "text",
+      });
+      const raw = await $fetch(`/${indexName}`, fetchOptions);
+      const text = typeof raw === "string" ? raw : String(raw);
+      const lines = text.split("\n").filter((line) => line.trim());
 
-          const cleanedUrl = cleanDoubleSlashes(record.url || "");
-          const snapUrl = `${dataBaseURL}/${record.filename}`;
-          pages.push({
-            url: cleanedUrl,
-            timestamp: isoTimestamp,
-            snapshot: snapUrl,
-            _meta: {
-              timestamp: record.timestamp,
-              status: Number.parseInt(record.status || "0", 10),
-              digest: record.digest,
-              mime: record.mime,
-              length: record.length,
-              offset: record.offset,
-              filename: record.filename,
-              collection: collectionName,
-              provider: "commoncrawl",
-            } as CommonCrawlMetadata,
-          });
-        }
-
-        return createSuccessResponse(pages, "commoncrawl", {
+      if (lines.length === 0) {
+        return createSuccessResponse([], "commoncrawl", {
           collection: collectionName,
-          count: pages.length,
           queryParams: fetchOptions.params,
         });
-      } catch (error) {
-        return createErrorResponse(error, "commoncrawl", { collection: collectionName });
       }
-    },
-  };
+
+      const records = lines.map((line) => JSON.parse(line) as Record<string, string>);
+      const pages: ArchivedPage[] = [];
+
+      for (const record of records) {
+        const isoTimestamp = waybackTimestampToISO(record.timestamp || "");
+        if (!isoTimestamp) {
+          consola.debug("[commoncrawl] Dropping record with invalid timestamp", {
+            timestamp: record.timestamp,
+            url: record.url,
+          });
+          continue;
+        }
+
+        const cleanedUrl = cleanDoubleSlashes(record.url || "");
+        const snapUrl = `${dataBaseURL}/${record.filename}`;
+        pages.push({
+          url: cleanedUrl,
+          timestamp: isoTimestamp,
+          snapshot: snapUrl,
+          _meta: {
+            timestamp: record.timestamp,
+            status: Number.parseInt(record.status || "0", 10),
+            digest: record.digest,
+            mime: record.mime,
+            length: record.length,
+            offset: record.offset,
+            filename: record.filename,
+            collection: collectionName,
+            provider: "commoncrawl",
+          } as CommonCrawlMetadata,
+        });
+      }
+
+      return createSuccessResponse(pages, "commoncrawl", {
+        collection: collectionName,
+        count: pages.length,
+        queryParams: fetchOptions.params,
+      });
+    } catch (error) {
+      return createErrorResponse(error, "commoncrawl", { collection: collectionName });
+    }
+  }
+}
+
+export default function commonCrawl(
+  initOptions: Partial<CommonCrawlOptions> = {},
+): CommonCrawlProvider {
+  return new CommonCrawlProvider(initOptions);
 }

--- a/src/providers/commoncrawl.ts
+++ b/src/providers/commoncrawl.ts
@@ -15,13 +15,9 @@ import { BaseProvider } from "./base-provider";
 /**
  * Common Crawl archive provider.
  */
-export class CommonCrawlProvider extends BaseProvider {
+export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
   readonly name = "Common Crawl";
   readonly slug = "commoncrawl";
-
-  constructor(readonly options: Partial<CommonCrawlOptions> = {}) {
-    super(options);
-  }
 
   /**
    * Cache key extension that separates storage entries by collection.
@@ -44,7 +40,7 @@ export class CommonCrawlProvider extends BaseProvider {
     let collectionName: string | undefined;
 
     try {
-      const options = await this.resolveOptions<CommonCrawlOptions>(reqOptions);
+      const options = await this.resolveOptions(reqOptions);
 
       // resolve collection: explicit option, or latest via collinfo.json
       collectionName = options.collection as string | undefined;

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -22,8 +22,8 @@ export const providers = {
    * ```
    */
   async wayback(options?: WaybackOptions): Promise<ArchiveProvider> {
-    const { default: create } = await import("./wayback");
-    return create(options);
+    const { WaybackProvider } = await import("./wayback");
+    return new WaybackProvider(options);
   },
 
   /**
@@ -36,8 +36,8 @@ export const providers = {
    * ```
    */
   async archiveToday(options?: ArchiveTodayOptions): Promise<ArchiveProvider> {
-    const { default: create } = await import("./archive-today");
-    return create(options);
+    const { ArchiveTodayProvider } = await import("./archive-today");
+    return new ArchiveTodayProvider(options);
   },
 
   /**
@@ -49,9 +49,9 @@ export const providers = {
    * const permaccProvider = providers.permacc({ apiKey: 'your-api-key' })
    * ```
    */
-  async permacc(options?: PermaccOptions): Promise<ArchiveProvider> {
-    const { default: create } = await import("./permacc");
-    return create(options);
+  async permacc(options?: Partial<PermaccOptions>): Promise<ArchiveProvider> {
+    const { PermaccProvider } = await import("./permacc");
+    return new PermaccProvider(options);
   },
 
   /**
@@ -64,8 +64,8 @@ export const providers = {
    * ```
    */
   async commoncrawl(options?: CommonCrawlOptions): Promise<ArchiveProvider> {
-    const { default: create } = await import("./commoncrawl");
-    return create(options);
+    const { CommonCrawlProvider } = await import("./commoncrawl");
+    return new CommonCrawlProvider(options);
   },
 
   /**
@@ -78,8 +78,8 @@ export const providers = {
    * ```
    */
   async webcite(options?: WebCiteOptions): Promise<ArchiveProvider> {
-    const { default: create } = await import("./webcite");
-    return create(options);
+    const { WebCiteProvider } = await import("./webcite");
+    return new WebCiteProvider(options);
   },
 
   /**

--- a/src/providers/permacc.ts
+++ b/src/providers/permacc.ts
@@ -16,13 +16,9 @@ import { BaseProvider } from "./base-provider";
  * Perma.cc requires an API key. When neither init-time nor request-time
  * `apiKey` is provided, `snapshots()` returns an error response.
  */
-export class PermaccProvider extends BaseProvider {
+export class PermaccProvider extends BaseProvider<PermaccOptions> {
   readonly name = "Perma.cc";
   readonly slug = "permacc";
-
-  constructor(readonly options: Partial<PermaccOptions> = {}) {
-    super(options);
-  }
 
   /**
    * Fetch archived snapshots from Perma.cc.
@@ -32,7 +28,7 @@ export class PermaccProvider extends BaseProvider {
     reqOptions: Partial<PermaccOptions> = {},
   ): Promise<ArchiveResponse> {
     try {
-      const options = await this.resolveOptions<PermaccOptions>(reqOptions);
+      const options = await this.resolveOptions(reqOptions);
 
       if (!options.apiKey) {
         throw new Error("API key is required for Perma.cc");

--- a/src/providers/permacc.ts
+++ b/src/providers/permacc.ts
@@ -1,119 +1,121 @@
 import { $fetch } from "ofetch";
 import { cleanDoubleSlashes } from "ufo";
-import type { ArchiveProvider, ArchiveResponse, ArchivedPage } from "../types";
+import type { ArchiveResponse, ArchivedPage } from "../types";
 import type { PermaccOptions } from "../_providers";
 import {
   createSuccessResponse,
   createErrorResponse,
   createFetchOptions,
-  mergeOptions,
   normalizeDomain,
 } from "../utils";
+import { BaseProvider } from "./base-provider";
 
 /**
- * Create a Perma.cc archive provider.
+ * Perma.cc archive provider.
  *
- * @param initOptions - Initial Perma.cc options including required `apiKey` and cache settings.
- * @returns ArchiveProvider instance for fetching snapshots from Perma.cc.
+ * Perma.cc requires an API key. When neither init-time nor request-time
+ * `apiKey` is provided, `snapshots()` returns an error response.
  */
-export default function permacc(initOptions: Partial<PermaccOptions> = {}): ArchiveProvider {
-  return {
-    name: "Perma.cc",
-    slug: "permacc",
+export class PermaccProvider extends BaseProvider {
+  readonly name = "Perma.cc";
+  readonly slug = "permacc";
 
-    /**
-     * Fetch archived snapshots from Perma.cc.
-     *
-     * @param domain - The domain to fetch archives for.
-     * @param reqOptions - Request-specific Perma.cc options (e.g., apiKey, limit).
-     * @returns Promise resolving to ArchiveResponse containing pages and metadata.
-     */
-    async snapshots(
-      domain: string,
-      reqOptions: Partial<PermaccOptions> = {},
-    ): Promise<ArchiveResponse> {
-      try {
-        const options = await mergeOptions<PermaccOptions>(initOptions, reqOptions);
+  constructor(readonly options: Partial<PermaccOptions> = {}) {
+    super(options);
+  }
 
-        if (!options.apiKey) {
-          throw new Error("API key is required for Perma.cc");
-        }
+  /**
+   * Fetch archived snapshots from Perma.cc.
+   */
+  async snapshots(
+    domain: string,
+    reqOptions: Partial<PermaccOptions> = {},
+  ): Promise<ArchiveResponse> {
+    try {
+      const options = await this.resolveOptions<PermaccOptions>(reqOptions);
 
-        const baseUrl = "https://api.perma.cc";
-        const snapshotUrl = "https://perma.cc";
-        const { apiKey } = options;
-        const cleanDomain = normalizeDomain(domain, false);
-
-        const fetchOptions = await createFetchOptions(
-          baseUrl,
-          {
-            limit: options.limit ?? 100,
-            url: cleanDomain,
-          },
-          {
-            headers: {
-              Authorization: `ApiKey ${apiKey}`,
-            },
-            retries: options.retries,
-            timeout: options.timeout,
-          },
-        );
-
-        interface PermaccArchive {
-          guid: string;
-          url: string;
-          title: string;
-          creation_timestamp: string;
-          status: string;
-          created_by: {
-            id: string;
-          };
-        }
-
-        interface PermaccResponse {
-          objects: PermaccArchive[];
-          meta: {
-            limit: number;
-            offset: number;
-            total_count: number;
-          };
-        }
-
-        const response = (await $fetch("/v1/public/archives/", fetchOptions)) as PermaccResponse;
-
-        if (!response.objects || response.objects.length === 0) {
-          return createSuccessResponse([], "permacc", { queryParams: fetchOptions.params });
-        }
-
-        const pages: ArchivedPage[] = response.objects
-          .filter((item) => item.url && item.url.includes(cleanDomain))
-          .map((item) => {
-            const cleanedUrl = cleanDoubleSlashes(item.url);
-            const snapUrl = `${snapshotUrl}/${item.guid}`;
-            const timestamp = item.creation_timestamp ?? new Date().toISOString();
-
-            const page: ArchivedPage = {
-              url: cleanedUrl,
-              timestamp,
-              snapshot: snapUrl,
-              _meta: {
-                guid: item.guid,
-                title: item.title,
-                status: item.status,
-                created_by: item.created_by?.id,
-              },
-            };
-
-            return page;
-          });
-
-        return createSuccessResponse(pages, "permacc", {
-          queryParams: fetchOptions.params,
-          meta: response.meta ?? {},
-        });
-      } catch (error) {
-        return createErrorResponse(error, "permacc");
+      if (!options.apiKey) {
+        throw new Error("API key is required for Perma.cc");
       }
-    },
-  };
+
+      const baseUrl = "https://api.perma.cc";
+      const snapshotUrl = "https://perma.cc";
+      const { apiKey } = options;
+      const cleanDomain = normalizeDomain(domain, false);
+
+      const fetchOptions = await createFetchOptions(
+        baseUrl,
+        {
+          limit: options.limit ?? 100,
+          url: cleanDomain,
+        },
+        {
+          headers: {
+            Authorization: `ApiKey ${apiKey}`,
+          },
+          retries: options.retries,
+          timeout: options.timeout,
+        },
+      );
+
+      interface PermaccArchive {
+        guid: string;
+        url: string;
+        title: string;
+        creation_timestamp: string;
+        status: string;
+        created_by: {
+          id: string;
+        };
+      }
+
+      interface PermaccResponse {
+        objects: PermaccArchive[];
+        meta: {
+          limit: number;
+          offset: number;
+          total_count: number;
+        };
+      }
+
+      const response = (await $fetch("/v1/public/archives/", fetchOptions)) as PermaccResponse;
+
+      if (!response.objects || response.objects.length === 0) {
+        return createSuccessResponse([], "permacc", { queryParams: fetchOptions.params });
+      }
+
+      const pages: ArchivedPage[] = response.objects
+        .filter((item) => item.url && item.url.includes(cleanDomain))
+        .map((item) => {
+          const cleanedUrl = cleanDoubleSlashes(item.url);
+          const snapUrl = `${snapshotUrl}/${item.guid}`;
+          const timestamp = item.creation_timestamp ?? new Date().toISOString();
+
+          const page: ArchivedPage = {
+            url: cleanedUrl,
+            timestamp,
+            snapshot: snapUrl,
+            _meta: {
+              guid: item.guid,
+              title: item.title,
+              status: item.status,
+              created_by: item.created_by?.id,
+            },
+          };
+
+          return page;
+        });
+
+      return createSuccessResponse(pages, "permacc", {
+        queryParams: fetchOptions.params,
+        meta: response.meta ?? {},
+      });
+    } catch (error) {
+      return createErrorResponse(error, "permacc");
+    }
+  }
+}
+
+export default function permacc(initOptions: Partial<PermaccOptions> = {}): PermaccProvider {
+  return new PermaccProvider(initOptions);
 }

--- a/src/providers/wayback.ts
+++ b/src/providers/wayback.ts
@@ -13,20 +13,16 @@ import { BaseProvider } from "./base-provider";
 /**
  * Wayback Machine archive provider.
  */
-export class WaybackProvider extends BaseProvider {
+export class WaybackProvider extends BaseProvider<WaybackOptions> {
   readonly name = "Internet Archive Wayback Machine";
   readonly slug = "wayback";
-
-  constructor(readonly options: WaybackOptions = {}) {
-    super(options);
-  }
 
   /**
    * Fetch archived snapshots from the Internet Archive Wayback Machine.
    */
   async snapshots(domain: string, reqOptions: WaybackOptions = {}): Promise<ArchiveResponse> {
     try {
-      const options = await this.resolveOptions<WaybackOptions>(reqOptions);
+      const options = await this.resolveOptions(reqOptions);
       const baseUrl = "https://web.archive.org";
       const snapshotUrl = "https://web.archive.org/web";
       const urlPattern = normalizeDomain(domain);

--- a/src/providers/wayback.ts
+++ b/src/providers/wayback.ts
@@ -1,74 +1,72 @@
 import { $fetch } from "ofetch";
-import type { ArchiveProvider, ArchiveResponse, ArchivedPage } from "../types";
+import type { ArchiveResponse, ArchivedPage } from "../types";
 import type { WaybackOptions } from "../_providers";
 import {
   normalizeDomain,
   createSuccessResponse,
   createErrorResponse,
   createFetchOptions,
-  mergeOptions,
   mapCdxRows,
 } from "../utils";
+import { BaseProvider } from "./base-provider";
 
 /**
- * Create a Wayback Machine archive provider.
- *
- * @param initOptions - Initial archive options for Wayback queries.
- * @returns ArchiveProvider instance for fetching snapshots from the Wayback Machine.
+ * Wayback Machine archive provider.
  */
-export default function wayback(initOptions: WaybackOptions = {}): ArchiveProvider {
-  return {
-    name: "Internet Archive Wayback Machine",
-    slug: "wayback",
+export class WaybackProvider extends BaseProvider {
+  readonly name = "Internet Archive Wayback Machine";
+  readonly slug = "wayback";
 
-    /**
-     * Fetch archived snapshots from the Internet Archive Wayback Machine.
-     *
-     * @param domain - The domain to search for archived snapshots.
-     * @param reqOptions - Request-specific options overriding initial settings.
-     * @returns Promise resolving to ArchiveResponse containing pages and metadata.
-     */
-    async snapshots(domain: string, reqOptions: WaybackOptions = {}): Promise<ArchiveResponse> {
-      try {
-        const options = await mergeOptions(initOptions, reqOptions);
-        const baseUrl = "https://web.archive.org";
-        const snapshotUrl = "https://web.archive.org/web";
-        const urlPattern = normalizeDomain(domain);
-        const params: Record<string, string> = {
-          url: urlPattern,
-          output: "json",
-          fl: "original,timestamp,statuscode",
-          collapse: options.collapse ?? "timestamp:4",
-          limit: String(options.limit ?? 1000),
-        };
+  constructor(readonly options: WaybackOptions = {}) {
+    super(options);
+  }
 
-        if (options.filter !== undefined) params.filter = options.filter;
+  /**
+   * Fetch archived snapshots from the Internet Archive Wayback Machine.
+   */
+  async snapshots(domain: string, reqOptions: WaybackOptions = {}): Promise<ArchiveResponse> {
+    try {
+      const options = await this.resolveOptions<WaybackOptions>(reqOptions);
+      const baseUrl = "https://web.archive.org";
+      const snapshotUrl = "https://web.archive.org/web";
+      const urlPattern = normalizeDomain(domain);
+      const params: Record<string, string> = {
+        url: urlPattern,
+        output: "json",
+        fl: "original,timestamp,statuscode",
+        collapse: options.collapse ?? "timestamp:4",
+        limit: String(options.limit ?? 1000),
+      };
 
-        const fetchOptions = await createFetchOptions(baseUrl, params, {
-          retries: options.retries,
-          timeout: options.timeout,
-        });
+      if (options.filter !== undefined) params.filter = options.filter;
 
-        type WaybackResponse = [string[], ...string[][]];
-        const response = (await $fetch("/cdx/search/cdx", fetchOptions)) as WaybackResponse;
+      const fetchOptions = await createFetchOptions(baseUrl, params, {
+        retries: options.retries,
+        timeout: options.timeout,
+      });
 
-        // first row is the header
-        if (!Array.isArray(response) || response.length <= 1) {
-          return createSuccessResponse([], "wayback", { queryParams: fetchOptions.params || {} });
-        }
+      type WaybackResponse = [string[], ...string[][]];
+      const response = (await $fetch("/cdx/search/cdx", fetchOptions)) as WaybackResponse;
 
-        const dataRows = response.slice(1);
-        const pages: ArchivedPage[] = await mapCdxRows(
-          dataRows,
-          snapshotUrl,
-          "wayback",
-          options,
-        );
-
-        return createSuccessResponse(pages, "wayback", { queryParams: fetchOptions.params || {} });
-      } catch (error) {
-        return createErrorResponse(error, "wayback");
+      if (!Array.isArray(response) || response.length <= 1) {
+        return createSuccessResponse([], "wayback", { queryParams: fetchOptions.params || {} });
       }
-    },
-  };
+
+      const dataRows = response.slice(1);
+      const pages: ArchivedPage[] = await mapCdxRows(
+        dataRows,
+        snapshotUrl,
+        "wayback",
+        options,
+      );
+
+      return createSuccessResponse(pages, "wayback", { queryParams: fetchOptions.params || {} });
+    } catch (error) {
+      return createErrorResponse(error, "wayback");
+    }
+  }
+}
+
+export default function wayback(initOptions: WaybackOptions = {}): WaybackProvider {
+  return new WaybackProvider(initOptions);
 }

--- a/src/providers/webcite.ts
+++ b/src/providers/webcite.ts
@@ -14,7 +14,7 @@ const UNSUPPORTED_LIST_REASON =
  * retrievable via direct webcitation.org/<id> URLs once a `getById` API is
  * added at the aggregator level.
  */
-export class WebCiteProvider extends BaseProvider {
+export class WebCiteProvider extends BaseProvider<WebCiteOptions> {
   readonly name = "WebCite";
   readonly slug = "webcite";
 

--- a/src/providers/webcite.ts
+++ b/src/providers/webcite.ts
@@ -1,33 +1,34 @@
 import type { ArchiveProvider, ArchiveResponse } from "../types";
 import type { WebCiteOptions } from "../_providers";
 import { createUnsupportedResponse } from "../utils";
+import { BaseProvider } from "./base-provider";
 
 const UNSUPPORTED_LIST_REASON =
   "WebCite has no list-by-domain API. Existing snapshots can be fetched directly via webcitation.org/<id>; new archives have not been accepted since ~2019.";
 
 /**
- * Create a WebCite archive provider.
+ * WebCite archive provider.
  *
- * Note: WebCite does not expose a list-by-domain endpoint, so `snapshots(domain)`
+ * WebCite does not expose a list-by-domain endpoint, so `snapshots(domain)`
  * always returns an unsupported response. Existing snapshots are still
  * retrievable via direct webcitation.org/<id> URLs once a `getById` API is
  * added at the aggregator level.
- *
- * @param initOptions - Initial archive options for WebCite queries (currently unused).
- * @returns ArchiveProvider instance for WebCite.
+ */
+export class WebCiteProvider extends BaseProvider {
+  readonly name = "WebCite";
+  readonly slug = "webcite";
+
+  async snapshots(_domain: string, _options: WebCiteOptions = {}): Promise<ArchiveResponse> {
+    return createUnsupportedResponse(UNSUPPORTED_LIST_REASON, "webcite", {
+      operation: "snapshots",
+    });
+  }
+}
+
+/**
+ * Create a WebCite archive provider.
+ * Backwards-compatible functional factory; prefer `new WebCiteProvider(...)`.
  */
 export default function webcite(_initOptions: Partial<WebCiteOptions> = {}): ArchiveProvider {
-  return {
-    name: "WebCite",
-    slug: "webcite",
-
-    async snapshots(
-      _domain: string,
-      _reqOptions: Partial<WebCiteOptions> = {},
-    ): Promise<ArchiveResponse> {
-      return createUnsupportedResponse(UNSUPPORTED_LIST_REASON, "webcite", {
-        operation: "snapshots",
-      });
-    },
-  };
+  return new WebCiteProvider(_initOptions);
 }

--- a/src/utils/_utils.ts
+++ b/src/utils/_utils.ts
@@ -149,6 +149,15 @@ export function normalizeDomain(domain: string, appendWildcard = true): string {
 }
 
 /**
+ * Remove a single trailing slash from a URL or path. Idempotent and safe
+ * on bare origins (no trailing slash → returned unchanged). Used by
+ * providers that strip trailing slashes for snapshot/original URLs.
+ */
+export function stripTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+/**
  * Creates a standardized success response object
  * @param pages Array of archived pages
  * @param source Source identifier for the provider

--- a/src/utils/_utils.ts
+++ b/src/utils/_utils.ts
@@ -149,15 +149,6 @@ export function normalizeDomain(domain: string, appendWildcard = true): string {
 }
 
 /**
- * Remove a single trailing slash from a URL or path. Idempotent and safe
- * on bare origins (no trailing slash → returned unchanged). Used by
- * providers that strip trailing slashes for snapshot/original URLs.
- */
-export function stripTrailingSlash(url: string): string {
-  return url.endsWith("/") ? url.slice(0, -1) : url;
-}
-
-/**
  * Creates a standardized success response object
  * @param pages Array of archived pages
  * @param source Source identifier for the provider

--- a/test/base-provider.test.ts
+++ b/test/base-provider.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { BaseProvider } from "../src/providers/base-provider";
+import type { ArchiveOptions, ArchiveResponse } from "../src/types";
+
+class ArrowProvider extends BaseProvider {
+  readonly name = "Arrow provider";
+  readonly slug = "arrow";
+
+  snapshots = async (
+    _domain: string,
+    _options?: ArchiveOptions,
+  ): Promise<ArchiveResponse> => ({
+    success: true,
+    pages: [],
+  });
+}
+
+class MethodProvider extends BaseProvider {
+  readonly name = "Method provider";
+  readonly slug = "method";
+
+  async snapshots(): Promise<ArchiveResponse> {
+    return { success: true, pages: [] };
+  }
+}
+
+describe("BaseProvider", () => {
+  it("supports snapshots implemented as an arrow field", async () => {
+    const provider = new ArrowProvider();
+    const snapshots = provider.snapshots;
+
+    await expect(snapshots("example.com")).resolves.toMatchObject({
+      success: true,
+      pages: [],
+    });
+  });
+
+  it("isolates provider state from caller-owned options", () => {
+    const options = { limit: 1 };
+    const provider = new MethodProvider(options);
+
+    options.limit = 2;
+
+    expect(provider.options.limit).toBe(1);
+  });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createArchive, UnsupportedOperationError, storage, resetConfig } from "../src";
+import { Archive, createArchive, UnsupportedOperationError, storage, resetConfig } from "../src";
 import createWayback from "../src/providers/wayback";
 import createWebCite from "../src/providers/webcite";
 import type { ArchiveProvider, ArchivedPage } from "../src/types";
@@ -98,6 +98,30 @@ describe("createArchive", () => {
       "example.com",
       expect.objectContaining({ timeout: 10_000, limit: 100 }),
     );
+  });
+
+  it("keeps snapshots callable when passed as a callback", async () => {
+    const archive = createArchive(successProvider("callback", []), { cache: false });
+    const snapshots = archive.snapshots;
+
+    await expect(snapshots("example.com")).resolves.toMatchObject({
+      success: true,
+      pages: [],
+    });
+  });
+});
+
+describe("Archive.resolveProviders", () => {
+  it("isolates provider state from caller-owned arrays", async () => {
+    const input = [successProvider("a", []), successProvider("b", [])];
+    const archive = new Archive(input);
+
+    input.pop();
+    const resolved = await archive.resolveProviders();
+    expect(resolved).toHaveLength(2);
+
+    resolved.pop();
+    await expect(archive.resolveProviders()).resolves.toHaveLength(2);
   });
 });
 

--- a/test/wayback.test.ts
+++ b/test/wayback.test.ts
@@ -51,6 +51,16 @@ describe("wayback machine", () => {
     );
   });
 
+  it("keeps snapshots callable when passed as a callback", async () => {
+    vi.mocked($fetch).mockResolvedValueOnce([["original", "timestamp", "statuscode"]]);
+    const snapshots = createWayback().snapshots;
+
+    const result = await snapshots("example.com");
+
+    expect(result.success).toBe(true);
+    expect(result.pages).toEqual([]);
+  });
+
   it("handles empty results", async () => {
     // Mock an empty response (only headers, no data rows)
     vi.mocked($fetch).mockResolvedValueOnce([


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oritwoen/omnichron/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `Archive` class for managing providers, options, snapshots, and page retrieval.
  - Added reusable result-combination functionality.
  - Exported archive, provider classes, and utilities from the package entry point.
  - Added support for registering individual or multiple providers.
  - Provider configuration can now be supplied incrementally.

- **Bug Fixes**
  - Improved callback usage reliability for archive and provider snapshot methods.
  - Isolated internal provider configuration from external mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->