### PR TITLE
fix: separate Wayback cache entries

### DIFF
--- a/src/providers/base-provider.ts
+++ b/src/providers/base-provider.ts
@@ -14,6 +14,9 @@ export abstract class BaseProvider<TOptions extends ArchiveOptions = ArchiveOpti
 {
   abstract readonly name: string;
   abstract readonly slug?: string;
+  cacheKey(_options?: ArchiveOptions): string | undefined {
+    return undefined;
+  }
 
   readonly options: Partial<TOptions>;
 

--- a/src/providers/commoncrawl.ts
+++ b/src/providers/commoncrawl.ts
@@ -1,7 +1,7 @@
 import { consola } from "consola";
 import { $fetch } from "ofetch";
 import { cleanDoubleSlashes } from "ufo";
-import type { ArchiveResponse, ArchivedPage, CommonCrawlMetadata } from "../types";
+import type { ArchiveOptions, ArchiveResponse, ArchivedPage, CommonCrawlMetadata } from "../types";
 import type { CommonCrawlOptions } from "../_providers";
 import {
   waybackTimestampToISO,
@@ -22,7 +22,7 @@ export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
   /**
    * Cache key extension that separates storage entries by collection.
    */
-  cacheKey(options?: import("../types").ArchiveOptions): string | undefined {
+  override cacheKey(options?: ArchiveOptions): string | undefined {
     const collection =
       (options as Partial<CommonCrawlOptions> | undefined)?.collection ?? this.options.collection;
     return collection === undefined ? undefined : `collection=${encodeURIComponent(collection)}`;

--- a/src/providers/wayback.ts
+++ b/src/providers/wayback.ts
@@ -20,7 +20,7 @@ export class WaybackProvider extends BaseProvider<WaybackOptions> {
   /**
    * Cache key extension for options that change the CDX result set.
    */
-  cacheKey(options?: ArchiveOptions): string {
+  override cacheKey(options?: ArchiveOptions): string {
     const waybackOptions = options as Partial<WaybackOptions> | undefined;
     const collapse = waybackOptions?.collapse ?? this.options.collapse ?? "timestamp:4";
     const filter = waybackOptions?.filter ?? this.options.filter;

--- a/src/providers/wayback.ts
+++ b/src/providers/wayback.ts
@@ -1,5 +1,5 @@
 import { $fetch } from "ofetch";
-import type { ArchiveResponse, ArchivedPage } from "../types";
+import type { ArchiveOptions, ArchiveResponse, ArchivedPage } from "../types";
 import type { WaybackOptions } from "../_providers";
 import {
   normalizeDomain,
@@ -16,6 +16,20 @@ import { BaseProvider } from "./base-provider";
 export class WaybackProvider extends BaseProvider<WaybackOptions> {
   readonly name = "Internet Archive Wayback Machine";
   readonly slug = "wayback";
+
+  /**
+   * Cache key extension for options that change the CDX result set.
+   */
+  cacheKey(options?: ArchiveOptions): string {
+    const waybackOptions = options as Partial<WaybackOptions> | undefined;
+    const collapse = waybackOptions?.collapse ?? this.options.collapse ?? "timestamp:4";
+    const filter = waybackOptions?.filter ?? this.options.filter;
+    const parts = [`collapse=${encodeURIComponent(collapse)}`];
+
+    if (filter !== undefined) parts.push(`filter=${encodeURIComponent(filter)}`);
+
+    return parts.join(":");
+  }
 
   /**
    * Fetch archived snapshots from the Internet Archive Wayback Machine.

--- a/test/base-provider.test.ts
+++ b/test/base-provider.test.ts
@@ -35,6 +35,12 @@ describe("BaseProvider", () => {
     });
   });
 
+  it("defaults to no provider-specific cache key", () => {
+    const provider = new MethodProvider();
+
+    expect(provider.cacheKey()).toBeUndefined();
+  });
+
   it("isolates provider state from caller-owned options", () => {
     const options = { limit: 1 };
     const provider = new MethodProvider(options);

--- a/test/wayback.test.ts
+++ b/test/wayback.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { $fetch } from "ofetch";
 import { createArchive, resetConfig, storage } from "../src";
 import createWayback from "../src/providers/wayback";
+import type { WaybackOptions } from "../src/_providers";
 
 vi.mock("ofetch", () => ({
   $fetch: vi.fn(),
@@ -96,6 +97,40 @@ describe("wayback machine", () => {
         }),
       }),
     );
+  });
+
+  it("separates cache entries for CDX collapse and filter options", async () => {
+    vi.mocked($fetch)
+      .mockResolvedValueOnce([
+        ["original", "timestamp", "statuscode"],
+        ["https://example.com/digest", "20220101000000", "200"],
+      ])
+      .mockResolvedValueOnce([
+        ["original", "timestamp", "statuscode"],
+        ["https://example.com/year", "20220101000000", "200"],
+      ])
+      .mockResolvedValueOnce([
+        ["original", "timestamp", "statuscode"],
+        ["https://example.com/not-found", "20220101000000", "200"],
+      ]);
+
+    const archive = createArchive(
+      createWayback({ collapse: "digest", filter: "statuscode:200" }),
+    );
+    const byYear: WaybackOptions = { collapse: "timestamp:4" };
+    const notFound: WaybackOptions = { filter: "statuscode:404" };
+
+    const first = await archive.snapshots("example.com");
+    const second = await archive.snapshots("example.com", byYear);
+    const third = await archive.snapshots("example.com", notFound);
+    const cachedFirst = await archive.snapshots("example.com");
+
+    expect(first.pages[0].url).toBe("https://example.com/digest");
+    expect(second.pages[0].url).toBe("https://example.com/year");
+    expect(third.pages[0].url).toBe("https://example.com/not-found");
+    expect(cachedFirst.fromCache).toBe(true);
+    expect(cachedFirst.pages[0].url).toBe("https://example.com/digest");
+    expect($fetch).toHaveBeenCalledTimes(3);
   });
 
   it("returns an error response when fetching fails", async () => {


### PR DESCRIPTION
Wayback cache was silently reusing snapshots across different `collapse` and `filter` queries. Those options are part of provider cache key now, with regression coverage for both. Wrong cached archive data is worse than no cache.

Closes #7

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oritwoen/omnichron/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

