### PR TITLE
fix: deduplicate multi-provider results

### DIFF
--- a/src/archive.ts
+++ b/src/archive.ts
@@ -34,9 +34,9 @@ type ProviderInput =
 /**
  * Combine per-provider responses into a single merged ArchiveResponse.
  *
- * Merges pages, deduplicates them by URL and timestamp while preserving the
- * first provider's entry, joins errors, and propagates unsupported operations
- * into `_meta`.
+ * Merges pages, deduplicates matching URLs and timestamps across providers
+ * while preserving distinct captures within each provider, joins errors, and
+ * propagates unsupported operations into `_meta`.
  * The combined response is marked `unsupported` only when *every* queried
  * provider was structurally unsupported.
  *
@@ -48,7 +48,7 @@ export function combineResults(
   limit?: number,
 ): ArchiveResponse {
   const allPages: ArchivedPage[] = [];
-  const seenPageKeys = new Set<string>();
+  const pageProviderByKey = new Map<string, string>();
   const errors: string[] = [];
   const unsupportedProviders: UnsupportedProviderRecord[] = [];
   let anySuccess = false;
@@ -59,8 +59,9 @@ export function combineResults(
       anySuccess = true;
       for (const page of response.pages) {
         const key = JSON.stringify([page.url, page.timestamp]);
-        if (seenPageKeys.has(key)) continue;
-        seenPageKeys.add(key);
+        const firstProvider = pageProviderByKey.get(key);
+        if (firstProvider !== undefined && firstProvider !== providerSlug) continue;
+        pageProviderByKey.set(key, providerSlug);
         allPages.push(page);
       }
     } else if (response.unsupported) {

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -34,8 +34,9 @@ type ProviderInput =
 /**
  * Combine per-provider responses into a single merged ArchiveResponse.
  *
- * Merges pages (deduping nothing – duplicates are the caller's filter problem),
- * joins errors, and propagates the unsupported-operations list into `_meta`.
+ * Merges pages, deduplicates them by URL and timestamp while preserving the
+ * first provider's entry, joins errors, and propagates unsupported operations
+ * into `_meta`.
  * The combined response is marked `unsupported` only when *every* queried
  * provider was structurally unsupported.
  *
@@ -47,6 +48,7 @@ export function combineResults(
   limit?: number,
 ): ArchiveResponse {
   const allPages: ArchivedPage[] = [];
+  const seenPageKeys = new Set<string>();
   const errors: string[] = [];
   const unsupportedProviders: UnsupportedProviderRecord[] = [];
   let anySuccess = false;
@@ -55,7 +57,12 @@ export function combineResults(
     const providerSlug = response._meta?.provider ?? "unknown";
     if (response.success) {
       anySuccess = true;
-      allPages.push(...response.pages);
+      for (const page of response.pages) {
+        const key = JSON.stringify([page.url, page.timestamp]);
+        if (seenPageKeys.has(key)) continue;
+        seenPageKeys.add(key);
+        allPages.push(page);
+      }
     } else if (response.unsupported) {
       unsupportedProviders.push({
         provider: providerSlug,

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -34,9 +34,9 @@ type ProviderInput =
 /**
  * Combine per-provider responses into a single merged ArchiveResponse.
  *
- * Merges pages, deduplicates matching URLs and timestamps across providers
- * while preserving distinct captures within each provider, joins errors, and
- * propagates unsupported operations into `_meta`.
+ * Merges pages, deduplicates matching URLs and timestamps across provider
+ * responses, collapses repeated captures within each response, joins errors,
+ * and propagates unsupported operations into `_meta`.
  * The combined response is marked `unsupported` only when *every* queried
  * provider was structurally unsupported.
  *
@@ -48,7 +48,7 @@ export function combineResults(
   limit?: number,
 ): ArchiveResponse {
   const allPages: ArchivedPage[] = [];
-  const pageProviderByKey = new Map<string, string>();
+  const priorResponsePageKeys = new Set<string>();
   const errors: string[] = [];
   const unsupportedProviders: UnsupportedProviderRecord[] = [];
   let anySuccess = false;
@@ -57,12 +57,30 @@ export function combineResults(
     const providerSlug = response._meta?.provider ?? "unknown";
     if (response.success) {
       anySuccess = true;
+      const responsePageKeys = new Set<string>();
+      const responseCaptureKeys = new Set<string>();
+
       for (const page of response.pages) {
-        const key = JSON.stringify([page.url, page.timestamp]);
-        const firstProvider = pageProviderByKey.get(key);
-        if (firstProvider !== undefined && firstProvider !== providerSlug) continue;
-        pageProviderByKey.set(key, providerSlug);
+        const pageKey = JSON.stringify([page.url, page.timestamp]);
+        const digest = page._meta.digest;
+        const captureIdentity =
+          typeof digest === "string" && digest.length > 0 ? digest : page.snapshot;
+        const captureKey = JSON.stringify([page.url, page.timestamp, captureIdentity]);
+
+        if (
+          priorResponsePageKeys.has(pageKey) ||
+          responseCaptureKeys.has(captureKey)
+        ) {
+          continue;
+        }
+
+        responsePageKeys.add(pageKey);
+        responseCaptureKeys.add(captureKey);
         allPages.push(page);
+      }
+
+      for (const pageKey of responsePageKeys) {
+        priorResponsePageKeys.add(pageKey);
       }
     } else if (response.unsupported) {
       unsupportedProviders.push({

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -125,6 +125,27 @@ describe("Archive.resolveProviders", () => {
   });
 });
 
+
+describe("combineResults / deduplication", () => {
+  it("keeps the first provider page for duplicate URL and timestamp before limiting", async () => {
+    const first = successProvider("first", [
+      { ...samplePage("first"), timestamp: "2023-01-02T00:00:00Z" },
+    ]);
+    const second = successProvider("second", [
+      { ...samplePage("second"), timestamp: "2023-01-02T00:00:00Z" },
+      { ...samplePage("older"), timestamp: "2023-01-01T00:00:00Z" },
+    ]);
+    const archive = createArchive([first, second], { cache: false });
+
+    const response = await archive.snapshots("example.com", { limit: 2 });
+
+    expect(response.pages.map((page) => page.snapshot)).toEqual([
+      "https://archive.example/first",
+      "https://archive.example/older",
+    ]);
+  });
+});
+
 // --- combineResults: unsupported propagation ---
 
 describe("combineResults / unsupported propagation", () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -127,10 +127,10 @@ describe("Archive.resolveProviders", () => {
 
 describe("combineResults / deduplication", () => {
   it("keeps the first provider page for duplicate URL and timestamp before limiting", async () => {
-    const first = successProvider("first", [
+    const first = successProvider("shared", [
       { ...samplePage("first"), timestamp: "2023-01-02T00:00:00Z" },
     ]);
-    const second = successProvider("second", [
+    const second = successProvider("shared", [
       { ...samplePage("second"), timestamp: "2023-01-02T00:00:00Z" },
       { ...samplePage("older"), timestamp: "2023-01-01T00:00:00Z" },
     ]);
@@ -144,6 +144,30 @@ describe("combineResults / deduplication", () => {
     ]);
   });
 
+  it("deduplicates provider responses without provider metadata", async () => {
+    const first: ArchiveProvider = {
+      name: "first",
+      snapshots: vi.fn().mockResolvedValue({
+        success: true,
+        pages: [samplePage("first")],
+      }),
+    };
+    const second: ArchiveProvider = {
+      name: "second",
+      snapshots: vi.fn().mockResolvedValue({
+        success: true,
+        pages: [samplePage("second")],
+      }),
+    };
+    const archive = createArchive([first, second], { cache: false });
+
+    const response = await archive.snapshots("example.com");
+
+    expect(response.pages.map((page) => page.snapshot)).toEqual([
+      "https://archive.example/first",
+    ]);
+  });
+
   it("preserves distinct captures from the same provider at the same timestamp", async () => {
     const commonCrawl = successProvider("commoncrawl", [
       {
@@ -153,6 +177,10 @@ describe("combineResults / deduplication", () => {
       {
         ...samplePage("commoncrawl-b"),
         _meta: { provider: "commoncrawl", digest: "digest-b" },
+      },
+      {
+        ...samplePage("commoncrawl-a"),
+        _meta: { provider: "commoncrawl", digest: "digest-a" },
       },
     ]);
     const archive = createArchive([commonCrawl, successProvider("other", [])], {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -125,7 +125,6 @@ describe("Archive.resolveProviders", () => {
   });
 });
 
-
 describe("combineResults / deduplication", () => {
   it("keeps the first provider page for duplicate URL and timestamp before limiting", async () => {
     const first = successProvider("first", [
@@ -142,6 +141,29 @@ describe("combineResults / deduplication", () => {
     expect(response.pages.map((page) => page.snapshot)).toEqual([
       "https://archive.example/first",
       "https://archive.example/older",
+    ]);
+  });
+
+  it("preserves distinct captures from the same provider at the same timestamp", async () => {
+    const commonCrawl = successProvider("commoncrawl", [
+      {
+        ...samplePage("commoncrawl-a"),
+        _meta: { provider: "commoncrawl", digest: "digest-a" },
+      },
+      {
+        ...samplePage("commoncrawl-b"),
+        _meta: { provider: "commoncrawl", digest: "digest-b" },
+      },
+    ]);
+    const archive = createArchive([commonCrawl, successProvider("other", [])], {
+      cache: false,
+    });
+
+    const response = await archive.snapshots("example.com");
+
+    expect(response.pages.map((page) => page.snapshot)).toEqual([
+      "https://archive.example/commoncrawl-a",
+      "https://archive.example/commoncrawl-b",
     ]);
   });
 });


### PR DESCRIPTION
Same snapshot shouldn't count twice just because two providers found it. Exact `url` and `timestamp` matches are collapsed before `limit` now, keeping first provider result.

Closes #9

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oritwoen/omnichron/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

