### PR TITLE
fix: respect resolveConfig options

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -70,8 +70,8 @@ export async function resolveConfig(
     rcFile?: string;
   } = {},
 ): Promise<OmnichronConfig> {
-  // Return cached config if already resolved
-  if (cachedConfig) {
+  const shouldCache = Object.keys(options).length === 0;
+  if (shouldCache && cachedConfig) {
     return cachedConfig;
   }
 
@@ -93,8 +93,9 @@ export async function resolveConfig(
   // Apply post-processing
   const resolvedConfig = await postProcessConfig(config as OmnichronConfig, defaults);
 
-  // Cache resolved config
-  cachedConfig = resolvedConfig;
+  if (shouldCache) {
+    cachedConfig = resolvedConfig;
+  }
 
   return resolvedConfig;
 }
@@ -141,8 +142,5 @@ export function resetConfig(): void {
 export async function getConfig(
   options?: Parameters<typeof resolveConfig>[0],
 ): Promise<OmnichronConfig> {
-  if (cachedConfig) {
-    return cachedConfig;
-  }
   return resolveConfig(options);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -70,7 +70,7 @@ export async function resolveConfig(
     rcFile?: string;
   } = {},
 ): Promise<OmnichronConfig> {
-  const shouldCache = Object.keys(options).length === 0;
+  const shouldCache = Object.values(options).every((value) => value === undefined);
   if (shouldCache && cachedConfig) {
     return cachedConfig;
   }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -68,24 +68,36 @@ describe("Config", () => {
   it.each([
     ["resolveConfig", resolveConfig],
     ["getConfig", getConfig],
-  ])("should not reuse cached config for explicit %s options", async (_name, load) => {
-    const otherConfig: OmnichronConfig = {
+  ])("should isolate explicit %s options from the default cache", async (_name, load) => {
+    const firstConfig: OmnichronConfig = {
       ...defaultMockConfig,
       storage: {
         ...defaultMockConfig.storage,
-        prefix: "other-prefix",
+        prefix: "first-prefix",
+      },
+    };
+    const secondConfig: OmnichronConfig = {
+      ...defaultMockConfig,
+      storage: {
+        ...defaultMockConfig.storage,
+        prefix: "second-prefix",
       },
     };
     mockedLoadConfig
-      .mockResolvedValueOnce({ config: { ...defaultMockConfig } })
-      .mockResolvedValueOnce({ config: otherConfig });
+      .mockResolvedValueOnce({ config: firstConfig })
+      .mockResolvedValueOnce({ config: secondConfig })
+      .mockResolvedValueOnce({ config: { ...defaultMockConfig } });
 
     const first = await load({ cwd: "/first/path" });
     const second = await load({ cwd: "/second/path" });
+    const defaultConfig = await load();
+    const cachedDefaultConfig = await load();
 
-    expect(first.storage.prefix).toBe("test-prefix");
-    expect(second.storage.prefix).toBe("other-prefix");
-    expect(mockedLoadConfig).toHaveBeenCalledTimes(2);
+    expect(first.storage.prefix).toBe("first-prefix");
+    expect(second.storage.prefix).toBe("second-prefix");
+    expect(defaultConfig.storage.prefix).toBe("test-prefix");
+    expect(cachedDefaultConfig.storage.prefix).toBe("test-prefix");
+    expect(mockedLoadConfig).toHaveBeenCalledTimes(3);
   });
 
   it("should reset config cache", async () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -68,6 +68,19 @@ describe("Config", () => {
   it.each([
     ["resolveConfig", resolveConfig],
     ["getConfig", getConfig],
+  ])("should reuse default cache for undefined %s options", async (_name, load) => {
+    await load();
+    mockedLoadConfig.mockClear();
+
+    const config = await load({ cwd: undefined, envName: undefined });
+
+    expect(config).toEqual(defaultMockConfig);
+    expect(mockedLoadConfig).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["resolveConfig", resolveConfig],
+    ["getConfig", getConfig],
   ])("should isolate explicit %s options from the default cache", async (_name, load) => {
     const firstConfig: OmnichronConfig = {
       ...defaultMockConfig,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -65,6 +65,29 @@ describe("Config", () => {
     expect(mockedLoadConfig).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["resolveConfig", resolveConfig],
+    ["getConfig", getConfig],
+  ])("should not reuse cached config for explicit %s options", async (_name, load) => {
+    const otherConfig: OmnichronConfig = {
+      ...defaultMockConfig,
+      storage: {
+        ...defaultMockConfig.storage,
+        prefix: "other-prefix",
+      },
+    };
+    mockedLoadConfig
+      .mockResolvedValueOnce({ config: { ...defaultMockConfig } })
+      .mockResolvedValueOnce({ config: otherConfig });
+
+    const first = await load({ cwd: "/first/path" });
+    const second = await load({ cwd: "/second/path" });
+
+    expect(first.storage.prefix).toBe("test-prefix");
+    expect(second.storage.prefix).toBe("other-prefix");
+    expect(mockedLoadConfig).toHaveBeenCalledTimes(2);
+  });
+
   it("should reset config cache", async () => {
     // Arrange
     await getConfig(); // Cache the configuration


### PR DESCRIPTION
`resolveConfig()` was basically single-shot - first call poisoned every later call even with different `cwd`, `envName` or overrides. Explicit options skip shared cache now, plain calls still keep cheap singleton.

Closes #13

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oritwoen/omnichron/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

