### PR TITLE
fix: use authenticated Perma.cc URL lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,14 @@ const archive = createArchive(
 
 ### Perma.cc
 
-Perma.cc requires an API key:
+Perma.cc requires an API key and searches archives accessible to that account by exact submitted URL:
 
 ```ts
 const archive = createArchive(providers.permacc({ apiKey: "YOUR_API_KEY" }));
+const response = await archive.snapshots("https://example.com/page");
 ```
+
+A bare domain such as `example.com` is normalized to `https://example.com/`. It does not match every path on that domain.
 
 ### Error handling
 
@@ -95,7 +98,7 @@ try {
 | Wayback Machine | `providers.wayback()`      | web.archive.org CDX API                   |
 | Archive.today   | `providers.archiveToday()` | archive.ph via Memento timemap            |
 | Common Crawl    | `providers.commoncrawl()`  | Defaults to latest collection             |
-| Perma.cc        | `providers.permacc()`      | Requires `apiKey`                         |
+| Perma.cc        | `providers.permacc()`      | Requires `apiKey`; exact URL lookup only  |
 | WebCite         | `providers.webcite()`      | No list-by-domain API; `snapshots()` returns unsupported. New archives no longer accepted (~2019). |
 | All             | `providers.all()`          | All of the above except Perma.cc          |
 

--- a/packages/pi/extensions/omnichron.ts
+++ b/packages/pi/extensions/omnichron.ts
@@ -56,7 +56,7 @@ function loadOmnichron(): Promise<OmnichronModule> {
 }
 
 const PROVIDERS = ["auto", "all", "wayback", "archiveToday", "commoncrawl", "webcite", "permacc"] as const;
-const PROVIDER_HINT = `Provider to use. One of: ${PROVIDERS.join(", ")}. "auto" (or omit) uses "all", which queries Wayback, Archive.today, Common Crawl, and WebCite. Perma.cc requires an API key from an environment variable.`;
+const PROVIDER_HINT = `Provider to use. One of: ${PROVIDERS.join(", ")}. "auto" (or omit) uses "all", which queries Wayback, Archive.today, Common Crawl, and WebCite. Perma.cc requires an API key from an environment variable and searches exact URLs accessible to that account.`;
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 100;
 const PERMACC_API_KEY_ENVS = ["PERMA_CC_API_KEY", "PERMACC_API_KEY"] as const;
@@ -92,7 +92,7 @@ export default function omnichronExtension(pi: ExtensionAPI) {
 		name: "omnichron",
 		label: "Omnichron Snapshots",
 		description:
-			"Read-only/open-world network fetch: query web archive providers for archived snapshots of a domain or URL. Returns normalized pages with {url, timestamp, snapshot, _meta}. provider=all fans out to Wayback Machine, Archive.today, Common Crawl, and WebCite; provider=permacc reads its API key from PERMA_CC_API_KEY or PERMACC_API_KEY.",
+			"Read-only/open-world network fetch: query web archive providers for archived snapshots of a domain or URL. Returns normalized pages with {url, timestamp, snapshot, _meta}. provider=all fans out to Wayback Machine, Archive.today, Common Crawl, and WebCite; provider=permacc reads its API key from PERMA_CC_API_KEY or PERMACC_API_KEY and searches one exact URL.",
 		promptSnippet: "Find archived snapshots with omnichron; use provider=all for broad coverage and provider=wayback for fast Wayback-only lookup.",
 		promptGuidelines: [
 			"Use omnichron when the user asks for archived pages, Wayback/Common Crawl/Archive.today evidence, or historical snapshots of a URL/domain.",
@@ -324,8 +324,8 @@ function getProviderStatuses(): ProviderStatus[] {
 			requiresApiKey: true,
 			configured: permaccConfigured,
 			note: permaccConfigured
-				? `${envName} is set; provider=permacc reads only fixed Perma.cc env names.`
-				: `${PERMACC_API_KEY_ENVS.join("/")} is not set; provider=permacc needs one of them.`,
+				? `${envName} is set; provider=permacc searches this account for one exact URL.`
+				: `${PERMACC_API_KEY_ENVS.join("/")} is not set; provider=permacc needs one of them and an exact URL.`,
 		},
 	];
 }

--- a/src/providers/permacc.ts
+++ b/src/providers/permacc.ts
@@ -1,27 +1,114 @@
+import { createHash } from "node:crypto";
 import { $fetch } from "ofetch";
-import { cleanDoubleSlashes } from "ufo";
-import type { ArchiveResponse, ArchivedPage } from "../types";
+import { hasProtocol } from "ufo";
 import type { PermaccOptions } from "../_providers";
-import {
-  createSuccessResponse,
-  createErrorResponse,
-  createFetchOptions,
-  normalizeDomain,
-} from "../utils";
+import type { ArchiveOptions, ArchiveResponse, ArchivedPage } from "../types";
+import { createSuccessResponse, createErrorResponse, createFetchOptions } from "../utils";
 import { BaseProvider } from "./base-provider";
 
+function normalizeExactUrl(input: string): string {
+  const trimmedInput = input.trim();
+  const candidate = hasProtocol(trimmedInput, { strict: true })
+    ? trimmedInput
+    : `https://${trimmedInput}`;
+
+  let url: URL;
+  try {
+    url = new URL(candidate);
+  } catch {
+    throw new Error("Perma.cc requires a valid HTTP(S) URL");
+  }
+
+  if (
+    (url.protocol !== "http:" && url.protocol !== "https:") ||
+    url.username.length > 0 ||
+    url.password.length > 0
+  ) {
+    throw new Error("Perma.cc requires a valid HTTP(S) URL");
+  }
+
+  url.hash = "";
+  return url.href;
+}
+
+function mapArchive(value: unknown): ArchivedPage | undefined {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("guid" in value) ||
+    !("url" in value) ||
+    !("creation_timestamp" in value)
+  ) {
+    return undefined;
+  }
+
+  const { guid, url, creation_timestamp: creationTimestamp } = value;
+  if (
+    typeof guid !== "string" ||
+    guid.length === 0 ||
+    typeof url !== "string" ||
+    typeof creationTimestamp !== "string"
+  ) {
+    return undefined;
+  }
+
+  const timestamp = new Date(creationTimestamp);
+  if (!Number.isFinite(timestamp.getTime())) return undefined;
+
+  let archivedUrl: string;
+  try {
+    archivedUrl = normalizeExactUrl(url);
+  } catch {
+    return undefined;
+  }
+
+  const metadata: ArchivedPage["_meta"] = { guid };
+  if ("title" in value && typeof value.title === "string") metadata.title = value.title;
+  if ("status" in value && typeof value.status === "string") metadata.status = value.status;
+
+  const createdBy =
+    "created_by" in value &&
+    typeof value.created_by === "object" &&
+    value.created_by !== null &&
+    "id" in value.created_by
+      ? value.created_by.id
+      : undefined;
+  if (typeof createdBy === "string" || typeof createdBy === "number") {
+    metadata.created_by = String(createdBy);
+  }
+
+  return {
+    url: archivedUrl,
+    timestamp: timestamp.toISOString(),
+    snapshot: `https://perma.cc/${encodeURIComponent(guid)}`,
+    _meta: metadata,
+  };
+}
+
 /**
- * Perma.cc archive provider.
- *
- * Perma.cc requires an API key. When neither init-time nor request-time
- * `apiKey` is provided, `snapshots()` returns an error response.
+ * Perma.cc requires an API key and returns only archives accessible to that
+ * account. Lookups match one exact submitted URL; bare domains are normalized
+ * to their HTTPS root URL. When neither init-time nor request-time `apiKey` is
+ * provided, `snapshots()` returns an error response.
  */
 export class PermaccProvider extends BaseProvider<PermaccOptions> {
   readonly name = "Perma.cc";
   readonly slug = "permacc";
 
   /**
-   * Fetch archived snapshots from Perma.cc.
+   * Partition responses by account and effective limit without storing the raw API key.
+   */
+  override cacheKey(options?: ArchiveOptions): string | undefined {
+    const apiKey = options?.apiKey ?? this.options.apiKey;
+    if (!apiKey) return undefined;
+
+    const fingerprint = createHash("sha256").update(apiKey).digest("base64url");
+    const limit = options?.limit ?? this.options.limit ?? 100;
+    return `apiKey=${fingerprint},limit=${limit}`;
+  }
+
+  /**
+   * Fetch archives matching one exact URL from the authenticated Perma.cc account.
    */
   async snapshots(
     domain: string,
@@ -35,15 +122,14 @@ export class PermaccProvider extends BaseProvider<PermaccOptions> {
       }
 
       const baseUrl = "https://api.perma.cc";
-      const snapshotUrl = "https://perma.cc";
       const { apiKey } = options;
-      const cleanDomain = normalizeDomain(domain, false);
+      const exactUrl = normalizeExactUrl(domain);
 
       const fetchOptions = await createFetchOptions(
         baseUrl,
         {
           limit: options.limit ?? 100,
-          url: cleanDomain,
+          url: exactUrl,
         },
         {
           headers: {
@@ -54,60 +140,55 @@ export class PermaccProvider extends BaseProvider<PermaccOptions> {
         },
       );
 
-      interface PermaccArchive {
-        guid: string;
-        url: string;
-        title: string;
-        creation_timestamp: string;
-        status: string;
-        created_by: {
-          id: string;
-        };
+      const response: unknown = await $fetch("/v1/archives/", fetchOptions);
+      if (
+        typeof response !== "object" ||
+        response === null ||
+        !("objects" in response) ||
+        !Array.isArray(response.objects)
+      ) {
+        throw new Error("Invalid Perma.cc API response");
       }
 
-      interface PermaccResponse {
-        objects: PermaccArchive[];
-        meta: {
-          limit: number;
-          offset: number;
-          total_count: number;
-        };
+      const pages: ArchivedPage[] = [];
+      for (const archive of response.objects) {
+        const page = mapArchive(archive);
+        if (page) pages.push(page);
       }
 
-      const response = (await $fetch("/v1/public/archives/", fetchOptions)) as PermaccResponse;
-
-      if (!response.objects || response.objects.length === 0) {
-        return createSuccessResponse([], "permacc", { queryParams: fetchOptions.params });
+      const responseMeta: Record<string, unknown> = {};
+      if ("meta" in response && typeof response.meta === "object" && response.meta !== null) {
+        if ("limit" in response.meta && typeof response.meta.limit === "number") {
+          responseMeta.limit = response.meta.limit;
+        }
+        if ("offset" in response.meta && typeof response.meta.offset === "number") {
+          responseMeta.offset = response.meta.offset;
+        }
+        if ("total_count" in response.meta && typeof response.meta.total_count === "number") {
+          responseMeta.total_count = response.meta.total_count;
+        }
+        if (
+          "next" in response.meta &&
+          (typeof response.meta.next === "string" || response.meta.next === null)
+        ) {
+          responseMeta.next = response.meta.next;
+        }
+        if (
+          "previous" in response.meta &&
+          (typeof response.meta.previous === "string" || response.meta.previous === null)
+        ) {
+          responseMeta.previous = response.meta.previous;
+        }
       }
-
-      const pages: ArchivedPage[] = response.objects
-        .filter((item) => item.url && item.url.includes(cleanDomain))
-        .map((item) => {
-          const cleanedUrl = cleanDoubleSlashes(item.url);
-          const snapUrl = `${snapshotUrl}/${item.guid}`;
-          const timestamp = item.creation_timestamp ?? new Date().toISOString();
-
-          const page: ArchivedPage = {
-            url: cleanedUrl,
-            timestamp,
-            snapshot: snapUrl,
-            _meta: {
-              guid: item.guid,
-              title: item.title,
-              status: item.status,
-              created_by: item.created_by?.id,
-            },
-          };
-
-          return page;
-        });
 
       return createSuccessResponse(pages, "permacc", {
         queryParams: fetchOptions.params,
-        meta: response.meta ?? {},
+        meta: responseMeta,
       });
     } catch (error) {
-      return createErrorResponse(error, "permacc");
+      const message = error instanceof Error ? error.message : String(error);
+      const errorName = error instanceof Error ? error.name : "UnknownError";
+      return createErrorResponse(message, "permacc", { errorName });
     }
   }
 }

--- a/src/providers/permacc.ts
+++ b/src/providers/permacc.ts
@@ -31,6 +31,32 @@ function normalizeExactUrl(input: string): string {
   return url.href;
 }
 
+const ISO_TIMESTAMP_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+function parseCreationTimestamp(value: string): string | undefined {
+  const match = ISO_TIMESTAMP_PATTERN.exec(value);
+  if (!match) return undefined;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  if (month < 1 || month > 12 || hour > 23 || minute > 59 || second > 59) {
+    return undefined;
+  }
+
+  const isLeapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const hasThirtyDays = month === 4 || month === 6 || month === 9 || month === 11;
+  const daysInMonth = month === 2 ? (isLeapYear ? 29 : 28) : hasThirtyDays ? 30 : 31;
+  if (day < 1 || day > daysInMonth) return undefined;
+
+  const timestamp = new Date(value);
+  return Number.isFinite(timestamp.getTime()) ? timestamp.toISOString() : undefined;
+}
+
 function mapArchive(value: unknown): ArchivedPage | undefined {
   if (
     typeof value !== "object" ||
@@ -52,8 +78,8 @@ function mapArchive(value: unknown): ArchivedPage | undefined {
     return undefined;
   }
 
-  const timestamp = new Date(creationTimestamp);
-  if (!Number.isFinite(timestamp.getTime())) return undefined;
+  const timestamp = parseCreationTimestamp(creationTimestamp);
+  if (!timestamp) return undefined;
 
   let archivedUrl: string;
   try {
@@ -62,7 +88,7 @@ function mapArchive(value: unknown): ArchivedPage | undefined {
     return undefined;
   }
 
-  const metadata: ArchivedPage["_meta"] = { guid };
+  const metadata: ArchivedPage["_meta"] = { guid, timestamp: creationTimestamp };
   if ("title" in value && typeof value.title === "string") metadata.title = value.title;
   if ("status" in value && typeof value.status === "string") metadata.status = value.status;
 
@@ -79,7 +105,7 @@ function mapArchive(value: unknown): ArchivedPage | undefined {
 
   return {
     url: archivedUrl,
-    timestamp: timestamp.toISOString(),
+    timestamp,
     snapshot: `https://perma.cc/${encodeURIComponent(guid)}`,
     _meta: metadata,
   };

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -42,10 +42,7 @@ function getExpiresAt(ttl: ArchiveOptions["ttl"]): number | undefined {
   return Date.now() + Math.max(0, ttl);
 }
 
-function getCacheKeyParts(
-  provider: CacheKeyProvider,
-  options?: ArchiveOptions,
-): string[] {
+function getCacheKeyParts(provider: CacheKeyProvider, options?: ArchiveOptions): string[] {
   const parts: string[] = [];
 
   if (options?.limit !== undefined) parts.push(`limit=${options.limit}`);
@@ -88,10 +85,9 @@ export function generateStorageKey(
   options?: ArchiveOptions,
 ): string {
   const providerKey = provider.slug ?? provider.name;
-  const baseKey = `${storagePrefix}:${providerKey}:${domain}`;
-  const cacheKeyParts = getCacheKeyParts(provider, options);
+  const keyParts = [providerKey, domain, ...getCacheKeyParts(provider, options)];
 
-  return cacheKeyParts.length === 0 ? baseKey : `${baseKey}:${cacheKeyParts.join(":")}`;
+  return `${storagePrefix}:${JSON.stringify(keyParts)}`;
 }
 
 /**
@@ -190,7 +186,7 @@ export async function clearProviderStorage(
     }
 
     const providerKey = typeof provider === "string" ? provider : (provider.slug ?? provider.name);
-    const providerPrefix = `${storagePrefix}:${providerKey}:`;
+    const providerPrefix = `${storagePrefix}:[${JSON.stringify(providerKey)},`;
     const keys = await storage.getKeys();
 
     for (const key of keys) {

--- a/test/permacc.test.ts
+++ b/test/permacc.test.ts
@@ -1,67 +1,264 @@
+import { $fetch } from "ofetch";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createArchive, resetConfig, storage } from "../src";
 import createPermacc from "../src/providers/permacc";
-import { PermaccOptions } from "../src/_providers";
+import type { PermaccOptions } from "../src/_providers";
 
-// Mock fetch
-vi.mock("ofetch", () => {
+vi.mock("ofetch", () => ({
+  $fetch: vi.fn(),
+}));
+
+function permaResponse({
+  guid = "ABC123",
+  url = "https://example.com/",
+  creationTimestamp = "2023-01-01T12:00:00Z",
+}: {
+  guid?: string;
+  url?: string;
+  creationTimestamp?: string | null;
+} = {}) {
   return {
-    $fetch: vi.fn().mockImplementation(() => {
-      return {
-        objects: [
-          {
-            guid: "ABC123",
-            url: "https://example.com/page",
-            title: "Example Page",
-            creation_timestamp: "2023-01-01T12:00:00Z",
-            status: "success",
-            created_by: { id: "user1" },
-          },
-        ],
-        meta: {
-          limit: 100,
-          offset: 0,
-          total_count: 1,
-        },
-      };
-    }),
+    objects: [
+      {
+        guid,
+        url,
+        title: "Example Page",
+        creation_timestamp: creationTimestamp,
+        status: "success",
+        created_by: { id: 1 },
+      },
+    ],
+    meta: {
+      limit: 100,
+      offset: 0,
+      total_count: 1,
+      next: "/v1/archives/?limit=100&offset=100",
+      previous: null,
+    },
   };
-});
+}
 
 describe("Perma.cc Platform", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+  beforeEach(async () => {
+    await storage.clear();
+    resetConfig();
+    vi.resetAllMocks();
+    vi.mocked($fetch).mockResolvedValue(permaResponse());
   });
 
-  it("should require an API key", async () => {
+  it("requires an API key", async () => {
     const permacc = createPermacc({} as PermaccOptions);
     const result = await permacc.snapshots("example.com");
 
     expect(result.success).toBe(false);
     expect(result.error).toBe("API key is required for Perma.cc");
+    expect($fetch).not.toHaveBeenCalled();
   });
 
-  it("should fetch and format archived pages", async () => {
+  it("queries the authenticated archive endpoint for an exact URL", async () => {
     const permacc = createPermacc({ apiKey: "test_key" });
     const result = await permacc.snapshots("example.com");
 
     expect(result.success).toBe(true);
     expect(result.pages).toHaveLength(1);
-
-    const page = result.pages[0];
-    expect(page.url).toBe("https://example.com/page");
-    expect(page.timestamp).toBe("2023-01-01T12:00:00Z");
-    expect(page.snapshot).toBe("https://perma.cc/ABC123");
-    expect(page._meta.guid).toBe("ABC123");
+    expect(result.pages[0]).toEqual({
+      url: "https://example.com/",
+      timestamp: "2023-01-01T12:00:00.000Z",
+      snapshot: "https://perma.cc/ABC123",
+      _meta: {
+        guid: "ABC123",
+        title: "Example Page",
+        status: "success",
+        created_by: "1",
+      },
+    });
+    expect(result._meta?.meta).toEqual({
+      limit: 100,
+      offset: 0,
+      total_count: 1,
+      next: "/v1/archives/?limit=100&offset=100",
+      previous: null,
+    });
+    expect($fetch).toHaveBeenCalledWith(
+      "/v1/archives/",
+      expect.objectContaining({
+        baseURL: "https://api.perma.cc",
+        headers: {
+          Authorization: "ApiKey test_key",
+        },
+        params: {
+          limit: 100,
+          url: "https://example.com/",
+        },
+      }),
+    );
   });
 
-  it("should support the limit option", async () => {
+  it("preserves a target path and query while removing its fragment", async () => {
+    vi.mocked($fetch).mockResolvedValueOnce(
+      permaResponse({ url: "http://example.com/Page?version=1" }),
+    );
+    const permacc = createPermacc({ apiKey: "test_key" });
+
+    await permacc.snapshots("http://Example.com/Page?version=1#section");
+
+    expect($fetch).toHaveBeenCalledWith(
+      "/v1/archives/",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          url: "http://example.com/Page?version=1",
+        }),
+      }),
+    );
+  });
+
+  it("normalizes a bare host with a port", async () => {
+    const permacc = createPermacc({ apiKey: "test_key" });
+
+    await permacc.snapshots("localhost:8080/page");
+
+    expect($fetch).toHaveBeenCalledWith(
+      "/v1/archives/",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          url: "https://localhost:8080/page",
+        }),
+      }),
+    );
+  });
+
+  it("passes the requested result limit to Perma.cc", async () => {
     const permacc = createPermacc({
       apiKey: "test_key",
       limit: 50,
     });
 
     const result = await permacc.snapshots("example.com");
+
     expect(result.success).toBe(true);
-    expect(result.pages[0].snapshot).toBe("https://perma.cc/ABC123");
+    expect($fetch).toHaveBeenCalledWith(
+      "/v1/archives/",
+      expect.objectContaining({
+        params: expect.objectContaining({ limit: 50 }),
+      }),
+    );
+  });
+
+  it("does not fabricate timestamps for malformed archive records", async () => {
+    vi.mocked($fetch).mockResolvedValueOnce(permaResponse({ creationTimestamp: null }));
+    const permacc = createPermacc({ apiKey: "test_key" });
+
+    const result = await permacc.snapshots("example.com");
+
+    expect(result.success).toBe(true);
+    expect(result.pages).toEqual([]);
+  });
+
+  it("returns an error response for an invalid API payload", async () => {
+    vi.mocked($fetch).mockResolvedValueOnce({ objects: null });
+    const permacc = createPermacc({ apiKey: "test_key" });
+
+    const result = await permacc.snapshots("example.com");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Invalid Perma.cc API response");
+  });
+
+  it("does not expose an API key through request error metadata", async () => {
+    const requestError = Object.assign(new Error("Perma.cc request failed"), {
+      options: {
+        headers: {
+          Authorization: "ApiKey test-secret-key",
+        },
+      },
+    });
+    vi.mocked($fetch).mockRejectedValueOnce(requestError);
+    const permacc = createPermacc({ apiKey: "test-secret-key" });
+
+    const result = await permacc.snapshots("example.com");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Perma.cc request failed");
+    expect(result._meta?.errorDetails).toBe("Perma.cc request failed");
+    expect(result._meta?.errorName).toBe("Error");
+    expect(JSON.stringify(result)).not.toContain("test-secret-key");
+  });
+
+  it("separates cached responses by API key without storing raw keys", async () => {
+    vi.mocked($fetch)
+      .mockResolvedValueOnce(permaResponse({ guid: "FIRST" }))
+      .mockResolvedValueOnce(permaResponse({ guid: "SECOND" }));
+    const permacc = createPermacc({ apiKey: "first-secret-key" });
+    const archive = createArchive(permacc);
+
+    const first = await archive.snapshots("example.com");
+    const second = await archive.snapshots("example.com", { apiKey: "second-secret-key" });
+    const cachedFirst = await archive.snapshots("example.com");
+
+    expect(first.pages[0].snapshot).toBe("https://perma.cc/FIRST");
+    expect(second.pages[0].snapshot).toBe("https://perma.cc/SECOND");
+    expect(cachedFirst.pages[0].snapshot).toBe("https://perma.cc/FIRST");
+    expect(cachedFirst.fromCache).toBe(true);
+    expect($fetch).toHaveBeenCalledTimes(2);
+
+    const cacheKeys = (await storage.getKeys()).join("\n");
+    expect(cacheKeys).not.toContain("first-secret-key");
+    expect(cacheKeys).not.toContain("second-secret-key");
+  });
+
+  it("isolates cache entries between provider instances", async () => {
+    vi.mocked($fetch)
+      .mockResolvedValueOnce(permaResponse({ guid: "FIRST" }))
+      .mockResolvedValueOnce(permaResponse({ guid: "SECOND" }));
+    const firstArchive = createArchive(createPermacc({ apiKey: "first-secret-key" }));
+    const secondArchive = createArchive(createPermacc({ apiKey: "second-secret-key" }));
+
+    const first = await firstArchive.snapshots("example.com");
+    const second = await secondArchive.snapshots("example.com");
+    const cachedFirst = await firstArchive.snapshots("example.com");
+
+    expect(first.pages[0].snapshot).toBe("https://perma.cc/FIRST");
+    expect(second.pages[0].snapshot).toBe("https://perma.cc/SECOND");
+    expect(cachedFirst.pages[0].snapshot).toBe("https://perma.cc/FIRST");
+    expect(cachedFirst.fromCache).toBe(true);
+    expect($fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("separates cached responses by provider-level limits", async () => {
+    vi.mocked($fetch)
+      .mockResolvedValueOnce(permaResponse({ guid: "FIRST" }))
+      .mockResolvedValueOnce(permaResponse({ guid: "SECOND" }));
+    const firstArchive = createArchive(createPermacc({ apiKey: "test-secret-key", limit: 5 }));
+    const secondArchive = createArchive(createPermacc({ apiKey: "test-secret-key", limit: 10 }));
+
+    const first = await firstArchive.snapshots("example.com");
+    const second = await secondArchive.snapshots("example.com");
+
+    expect(first.pages[0].snapshot).toBe("https://perma.cc/FIRST");
+    expect(second.pages[0].snapshot).toBe("https://perma.cc/SECOND");
+    expect($fetch).toHaveBeenCalledTimes(2);
+    expect(vi.mocked($fetch).mock.calls[0][1]?.params).toEqual(
+      expect.objectContaining({ limit: 5 }),
+    );
+    expect(vi.mocked($fetch).mock.calls[1][1]?.params).toEqual(
+      expect.objectContaining({ limit: 10 }),
+    );
+  });
+
+  it("does not let URL text collide with an account cache partition", async () => {
+    const configuredProvider = createPermacc({ apiKey: "test-secret-key" });
+    const partition = configuredProvider.cacheKey();
+    if (!partition) throw new Error("Expected a Perma.cc cache partition");
+
+    const target = "https://example.com/private";
+    const configured = await createArchive(configuredProvider).snapshots(target);
+    const unauthenticated = await createArchive(createPermacc()).snapshots(
+      `${target}:${partition}`,
+    );
+
+    expect(configured.success).toBe(true);
+    expect(unauthenticated.success).toBe(false);
+    expect(unauthenticated.error).toBe("API key is required for Perma.cc");
+    expect($fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/permacc.test.ts
+++ b/test/permacc.test.ts
@@ -67,6 +67,7 @@ describe("Perma.cc Platform", () => {
       snapshot: "https://perma.cc/ABC123",
       _meta: {
         guid: "ABC123",
+        timestamp: "2023-01-01T12:00:00Z",
         title: "Example Page",
         status: "success",
         created_by: "1",
@@ -152,6 +153,30 @@ describe("Perma.cc Platform", () => {
 
     expect(result.success).toBe(true);
     expect(result.pages).toEqual([]);
+  });
+
+  it("rejects impossible calendar timestamps", async () => {
+    vi.mocked($fetch).mockResolvedValueOnce(
+      permaResponse({ creationTimestamp: "2023-02-29T12:00:00Z" }),
+    );
+    const permacc = createPermacc({ apiKey: "test_key" });
+
+    const result = await permacc.snapshots("example.com");
+
+    expect(result.success).toBe(true);
+    expect(result.pages).toEqual([]);
+  });
+
+  it("accepts leap-day timestamps in leap years", async () => {
+    vi.mocked($fetch).mockResolvedValueOnce(
+      permaResponse({ creationTimestamp: "2024-02-29T12:00:00Z" }),
+    );
+    const permacc = createPermacc({ apiKey: "test_key" });
+
+    const result = await permacc.snapshots("example.com");
+
+    expect(result.success).toBe(true);
+    expect(result.pages[0]?.timestamp).toBe("2024-02-29T12:00:00.000Z");
   });
 
   it("returns an error response for an invalid API payload", async () => {


### PR DESCRIPTION
`PermaccProvider` was doing fake URL filtering over Perma.cc's public recent feed. It required an API key but never used it, then searched only that one page with `includes()` and could return wrong archives.

Uses authenticated `/v1/archives/` exact URL lookup now, keeps full path and query, and rejects malformed records instead of inventing timestamps. Cache is split by account and effective limit too, with structured keys so URL text can't collide with auth partition.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/oritwoen/omnichron/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

