### PR TITLE
feat: add Archive-It provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Unified TypeScript interface for querying web archive providers. One API, multip
 
 ## Features
 
-- 🔍 **Multiple providers** - Wayback Machine, Archive.today, Common Crawl, Perma.cc, WebCite
+- 🔍 **Multiple providers** - Wayback Machine, Archive-It, Archive.today, Common Crawl, Perma.cc, WebCite
 - 🌳 **Tree-shakable** - providers are lazy-loaded via dynamic imports, bundle only what you use
 - 📦 **Caching built in** - pluggable storage layer via [unstorage](https://github.com/unjs/unstorage) with configurable TTL
 - ⚡ **Parallel queries** - concurrency control, batching, automatic retries, configurable timeouts
@@ -63,6 +63,17 @@ const response = await archive.snapshots("https://example.com/page");
 
 A bare domain such as `example.com` is normalized to `https://example.com/`. It does not match every path on that domain.
 
+### Archive-It
+
+Archive-It queries one public collection at a time through its CDX/C API. Pass the numeric collection ID when creating the provider:
+
+```ts
+const archive = createArchive(providers.archiveIt({ collection: 4399 }));
+const response = await archive.snapshots("archive-it.org");
+```
+
+Archive-It’s all-collections endpoint is temporarily blocked, so `providers.archiveIt()` requires a collection and is not included in `providers.all()`.
+
 ### Error handling
 
 `snapshots()` returns a response object with a `success` flag. If you prefer throwing on failure, use `getPages()`:
@@ -75,7 +86,7 @@ const response = await archive.snapshots("example.com");
 const pages = await archive.getPages("example.com");
 ```
 
-`getPages()` distinguishes runtime failures from structural ones. When every queried provider is *unsupported* for the operation (see below), it throws `UnsupportedOperationError` with the per-provider reasons attached:
+`getPages()` distinguishes runtime failures from structural ones. When every queried provider is _unsupported_ for the operation (see below), it throws `UnsupportedOperationError` with the per-provider reasons attached:
 
 ```ts
 import { UnsupportedOperationError } from "@agntn/archives";
@@ -93,14 +104,15 @@ try {
 
 ## Providers
 
-| Provider        | Factory                    | Notes                                     |
-| --------------- | -------------------------- | ----------------------------------------- |
-| Wayback Machine | `providers.wayback()`      | web.archive.org CDX API                   |
-| Archive.today   | `providers.archiveToday()` | archive.ph via Memento timemap            |
-| Common Crawl    | `providers.commoncrawl()`  | Defaults to latest collection             |
-| Perma.cc        | `providers.permacc()`      | Requires `apiKey`; exact URL lookup only  |
+| Provider        | Factory                    | Notes                                                                                              |
+| --------------- | -------------------------- | -------------------------------------------------------------------------------------------------- |
+| Wayback Machine | `providers.wayback()`      | web.archive.org CDX API                                                                            |
+| Archive-It      | `providers.archiveIt()`    | Requires a numeric `collection`; collection-specific CDX/C API                                     |
+| Archive.today   | `providers.archiveToday()` | archive.ph via Memento timemap                                                                     |
+| Common Crawl    | `providers.commoncrawl()`  | Defaults to latest collection                                                                      |
+| Perma.cc        | `providers.permacc()`      | Requires `apiKey`; exact URL lookup only                                                           |
 | WebCite         | `providers.webcite()`      | No list-by-domain API; `snapshots()` returns unsupported. New archives no longer accepted (~2019). |
-| All             | `providers.all()`          | All of the above except Perma.cc          |
+| All             | `providers.all()`          | Wayback, Archive.today, Common Crawl, and WebCite                                                  |
 
 You can add providers dynamically after creation:
 
@@ -160,11 +172,11 @@ Not every provider implements every operation. WebCite, for example, exposes no 
 
 For multi-provider calls, the combined response surfaces unsupported providers under `_meta.unsupportedProviders` regardless of how the rest behaved. The top-level `unsupported` flag has stricter semantics:
 
-| Scenario                                                  | `success` | `error`        | `unsupported` | `_meta.unsupportedProviders` |
-| --------------------------------------------------------- | --------- | -------------- | ------------- | ---------------------------- |
-| Some providers succeed, others are unsupported            | `true`    | —              | —             | populated                    |
-| Some providers error, others are unsupported, none succeed | `false`   | joined errors  | —             | populated                    |
-| Every queried provider is unsupported                     | `false`   | —              | `true`         | populated                    |
+| Scenario                                                   | `success` | `error`       | `unsupported` | `_meta.unsupportedProviders` |
+| ---------------------------------------------------------- | --------- | ------------- | ------------- | ---------------------------- |
+| Some providers succeed, others are unsupported             | `true`    | —             | —             | populated                    |
+| Some providers error, others are unsupported, none succeed | `false`   | joined errors | —             | populated                    |
+| Every queried provider is unsupported                      | `false`   | —             | `true`        | populated                    |
 
 Example:
 
@@ -177,7 +189,7 @@ response._meta?.unsupportedProviders;
 // [{ provider: "webcite", reason: "WebCite has no list-by-domain API. ..." }]
 ```
 
-To treat unsupported providers as a *whole-call* failure, check the top-level flag explicitly: `if (!response.success && response.unsupported) { ... }`.
+To treat unsupported providers as a _whole-call_ failure, check the top-level flag explicitly: `if (!response.success && response.unsupported) { ... }`.
 
 ## Configuration
 
@@ -261,7 +273,7 @@ Options can be set at three levels: config file (global defaults), `createArchiv
 
 ## Roadmap
 
-**Providers:** Archive-It, Conifer (formerly Webrecorder)
+**Providers:** Conifer (formerly Webrecorder)
 
 **Features:** Page archiving API for creating archives, not just reading them
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ if (response.success) {
 }
 ```
 
-Query all providers at once with `providers.all()` (excludes Perma.cc since it needs an API key):
+Query all providers at once with `providers.all()` (excludes Archive-It because it needs a collection ID and Perma.cc because it needs an API key):
 
 ```ts
 const archive = createArchive(providers.all());

--- a/packages/omp/extensions/archives.ts
+++ b/packages/omp/extensions/archives.ts
@@ -68,12 +68,13 @@ const PROVIDERS = [
   "auto",
   "all",
   "wayback",
+  "archiveIt",
   "archiveToday",
   "commoncrawl",
   "webcite",
   "permacc",
 ] as const;
-const PROVIDER_HINT = `Provider to use. One of: ${PROVIDERS.join(", ")}. "auto" (or omit) uses "all", which queries Wayback, Archive.today, Common Crawl, and WebCite. Perma.cc requires an API key from an environment variable and searches exact URLs accessible to that account.`;
+const PROVIDER_HINT = `Provider to use. One of: ${PROVIDERS.join(", ")}. "auto" (or omit) uses "all", which queries Wayback, Archive.today, Common Crawl, and WebCite. Archive-It requires a numeric collection id. Perma.cc requires an API key from an environment variable and searches exact URLs accessible to that account.`;
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 100;
 const PERMACC_API_KEY_ENVS = ["PERMA_CC_API_KEY", "PERMACC_API_KEY"] as const;
@@ -115,7 +116,10 @@ const snapshotParameters = Type.Object({
     Type.Integer({ description: "Retry attempts for failed requests.", minimum: 0 }),
   ),
   collection: Type.Optional(
-    Type.String({ description: "Common Crawl collection id, e.g. CC-MAIN-latest." }),
+    Type.String({
+      description:
+        "Archive-It numeric collection id, or Common Crawl collection id such as CC-MAIN-latest.",
+    }),
   ),
   collapse: Type.Optional(
     Type.String({ description: "Wayback CDX collapse parameter, e.g. timestamp:4." }),
@@ -259,6 +263,16 @@ async function createProvider(
 ): Promise<ArchiveProvider | ArchiveProvider[]> {
   if (provider === "all") return archives.providers.all(options);
   if (provider === "wayback") return archives.providers.wayback(options);
+  if (provider === "archiveIt") {
+    const collection = options.collection?.trim();
+    if (collection === undefined || !/^\d+$/.test(collection)) {
+      throw new Error("provider=archiveIt requires a numeric collection id.");
+    }
+    return archives.providers.archiveIt({
+      ...options,
+      collection,
+    });
+  }
   if (provider === "archiveToday") return archives.providers.archiveToday(options);
   if (provider === "commoncrawl") return archives.providers.commoncrawl(options);
   if (provider === "webcite") return archives.providers.webcite(options);
@@ -268,6 +282,7 @@ async function createProvider(
 function normalizeProvider(provider: string | undefined): ProviderName {
   const raw = (provider ?? "auto").trim() || "auto";
   if (raw === "archive-today") return "archiveToday";
+  if (raw === "archive-it") return "archiveIt";
   if (!isKnownProvider(raw)) {
     throw new Error(`Unknown provider "${raw}". Available: ${PROVIDERS.join(", ")}.`);
   }
@@ -342,6 +357,14 @@ function getProviderStatuses(): ProviderStatus[] {
       requiresApiKey: false,
       configured: true,
       note: "Internet Archive CDX API.",
+    },
+    {
+      name: "archiveIt",
+      factory: "providers.archiveIt({ collection })",
+      includedInAll: false,
+      requiresApiKey: false,
+      configured: true,
+      note: "Archive-It collection CDX/C API; requires a numeric collection.",
     },
     {
       name: "archiveToday",

--- a/packages/pi/extensions/archives.ts
+++ b/packages/pi/extensions/archives.ts
@@ -64,12 +64,13 @@ const PROVIDERS = [
   "auto",
   "all",
   "wayback",
+  "archiveIt",
   "archiveToday",
   "commoncrawl",
   "webcite",
   "permacc",
 ] as const;
-const PROVIDER_HINT = `Provider to use. One of: ${PROVIDERS.join(", ")}. "auto" (or omit) uses "all", which queries Wayback, Archive.today, Common Crawl, and WebCite. Perma.cc requires an API key from an environment variable and searches exact URLs accessible to that account.`;
+const PROVIDER_HINT = `Provider to use. One of: ${PROVIDERS.join(", ")}. "auto" (or omit) uses "all", which queries Wayback, Archive.today, Common Crawl, and WebCite. Archive-It requires a numeric collection id. Perma.cc requires an API key from an environment variable and searches exact URLs accessible to that account.`;
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 100;
 const PERMACC_API_KEY_ENVS = ["PERMA_CC_API_KEY", "PERMACC_API_KEY"] as const;
@@ -105,7 +106,10 @@ const snapshotParameters = Type.Object({
     Type.Number({ description: "Retry attempts for failed requests.", minimum: 0 }),
   ),
   collection: Type.Optional(
-    Type.String({ description: "Common Crawl collection id, e.g. CC-MAIN-latest." }),
+    Type.String({
+      description:
+        "Archive-It numeric collection id, or Common Crawl collection id such as CC-MAIN-latest.",
+    }),
   ),
   collapse: Type.Optional(
     Type.String({ description: "Wayback CDX collapse parameter, e.g. timestamp:4." }),
@@ -256,6 +260,16 @@ async function createProvider(
 ): Promise<ArchiveProvider | ArchiveProvider[]> {
   if (provider === "all") return archives.providers.all(options);
   if (provider === "wayback") return archives.providers.wayback(options);
+  if (provider === "archiveIt") {
+    const collection = options.collection?.trim();
+    if (collection === undefined || !/^\d+$/.test(collection)) {
+      throw new Error("provider=archiveIt requires a numeric collection id.");
+    }
+    return archives.providers.archiveIt({
+      ...options,
+      collection,
+    });
+  }
   if (provider === "archiveToday") return archives.providers.archiveToday(options);
   if (provider === "commoncrawl") return archives.providers.commoncrawl(options);
   if (provider === "webcite") return archives.providers.webcite(options);
@@ -265,6 +279,7 @@ async function createProvider(
 function normalizeProvider(provider: string | undefined): ProviderName {
   const raw = (provider ?? "auto").trim() || "auto";
   if (raw === "archive-today") return "archiveToday";
+  if (raw === "archive-it") return "archiveIt";
   if (!isKnownProvider(raw)) {
     throw new Error(`Unknown provider "${raw}". Available: ${PROVIDERS.join(", ")}.`);
   }
@@ -339,6 +354,14 @@ function getProviderStatuses(): ProviderStatus[] {
       requiresApiKey: false,
       configured: true,
       note: "Internet Archive CDX API.",
+    },
+    {
+      name: "archiveIt",
+      factory: "providers.archiveIt({ collection })",
+      includedInAll: false,
+      requiresApiKey: false,
+      configured: true,
+      note: "Archive-It collection CDX/C API; requires a numeric collection.",
     },
     {
       name: "archiveToday",

--- a/src/_providers.ts
+++ b/src/_providers.ts
@@ -5,6 +5,14 @@ export interface WaybackOptions extends ArchiveOptions {
   filter?: string;
 }
 
+export interface ArchiveItOptions extends ArchiveOptions {
+  collection: number | string;
+  collapse?: string;
+  filter?: string;
+  from?: string;
+  to?: string;
+}
+
 export type ArchiveTodayOptions = ArchiveOptions;
 
 export interface PermaccOptions extends ArchiveOptions {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 export type * from "./types";
+export type * from "./_providers";
 export { createArchive, Archive, UnsupportedOperationError, combineResults } from "./archive";
 export { BaseProvider } from "./providers/base-provider";
 export { WaybackProvider } from "./providers/wayback";
+export { ArchiveItProvider } from "./providers/archive-it";
 export { ArchiveTodayProvider } from "./providers/archive-today";
 export { PermaccProvider } from "./providers/permacc";
 export { CommonCrawlProvider } from "./providers/commoncrawl";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export type * from "./types";
-export type * from "./_providers";
+export type { ArchiveItOptions } from "./_providers";
 export { createArchive, Archive, UnsupportedOperationError, combineResults } from "./archive";
 export { BaseProvider } from "./providers/base-provider";
 export { WaybackProvider } from "./providers/wayback";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 export type * from "./types";
-export type { ArchiveItOptions } from "./_providers";
 export { createArchive, Archive, UnsupportedOperationError, combineResults } from "./archive";
 export { BaseProvider } from "./providers/base-provider";
 export { WaybackProvider } from "./providers/wayback";

--- a/src/providers/archive-it.ts
+++ b/src/providers/archive-it.ts
@@ -1,0 +1,98 @@
+import { $fetch } from "ofetch";
+import type { ArchiveOptions, ArchiveResponse } from "../types";
+import type { ArchiveItOptions } from "../_providers";
+import {
+  createErrorResponse,
+  createFetchOptions,
+  createSuccessResponse,
+  mapCdxRows,
+  normalizeDomain,
+} from "../utils";
+import { BaseProvider } from "./base-provider";
+
+/**
+ * Archive-It collection archive provider.
+ */
+export class ArchiveItProvider extends BaseProvider<ArchiveItOptions> {
+  readonly name = "Archive-It";
+  readonly slug = "archive-it";
+
+  constructor(options: ArchiveItOptions) {
+    super(options);
+  }
+
+  /**
+   * Cache key extension for the collection and filters that change the CDX result set.
+   */
+  override cacheKey(options?: ArchiveOptions): string {
+    const requestOptions = options as Partial<ArchiveItOptions> | undefined;
+    const collection = String(requestOptions?.collection ?? this.options.collection).trim();
+    const collapse = requestOptions?.collapse ?? this.options.collapse;
+    const filter = requestOptions?.filter ?? this.options.filter;
+    const from = requestOptions?.from ?? this.options.from;
+    const to = requestOptions?.to ?? this.options.to;
+    const parts = [`collection=${encodeURIComponent(collection)}`];
+
+    if (collapse !== undefined) parts.push(`collapse=${encodeURIComponent(collapse)}`);
+    if (filter !== undefined) parts.push(`filter=${encodeURIComponent(filter)}`);
+    if (from !== undefined) parts.push(`from=${encodeURIComponent(from)}`);
+    if (to !== undefined) parts.push(`to=${encodeURIComponent(to)}`);
+
+    return parts.join(":");
+  }
+
+  /**
+   * Fetch archived snapshots from one Archive-It collection.
+   */
+  async snapshots(
+    domain: string,
+    reqOptions: Partial<ArchiveItOptions> = {},
+  ): Promise<ArchiveResponse> {
+    try {
+      const options = await this.resolveOptions(reqOptions);
+      const collection = String(options.collection).trim();
+      if (!/^\d+$/.test(collection)) {
+        throw new Error("Archive-It collection must be a numeric collection ID");
+      }
+
+      const baseUrl = "https://wayback.archive-it.org";
+      const urlPattern = normalizeDomain(domain);
+      const params: Record<string, string> = {
+        url: urlPattern,
+        fl: "original,timestamp,statuscode",
+        limit: String(options.limit ?? 1000),
+      };
+
+      if (options.collapse !== undefined) params.collapse = options.collapse;
+      if (options.filter !== undefined) params.filter = options.filter;
+      if (options.from !== undefined) params.from = options.from;
+      if (options.to !== undefined) params.to = options.to;
+
+      const fetchOptions = await createFetchOptions(baseUrl, params, {
+        retries: options.retries,
+        timeout: options.timeout,
+      });
+      const response: string = await $fetch(`/${collection}/timemap/cdx`, {
+        ...fetchOptions,
+        responseType: "text",
+      });
+      const rows = response
+        .trim()
+        .split("\n")
+        .map((line) => line.trim().split(/\s+/))
+        .filter((row) => row.length >= 3);
+      const pages = await mapCdxRows(rows, `${baseUrl}/${collection}`, "archive-it", options);
+
+      return createSuccessResponse(pages, "archive-it", {
+        collection,
+        queryParams: fetchOptions.params || {},
+      });
+    } catch (error) {
+      return createErrorResponse(error, "archive-it");
+    }
+  }
+}
+
+export default function archiveIt(options: ArchiveItOptions): ArchiveItProvider {
+  return new ArchiveItProvider(options);
+}

--- a/src/providers/archive-it.ts
+++ b/src/providers/archive-it.ts
@@ -31,12 +31,14 @@ export class ArchiveItProvider extends BaseProvider<ArchiveItOptions> {
     const filter = requestOptions?.filter ?? this.options.filter;
     const from = requestOptions?.from ?? this.options.from;
     const to = requestOptions?.to ?? this.options.to;
+    const limit = requestOptions?.limit ?? this.options.limit;
     const parts = [`collection=${encodeURIComponent(collection)}`];
 
     if (collapse !== undefined) parts.push(`collapse=${encodeURIComponent(collapse)}`);
     if (filter !== undefined) parts.push(`filter=${encodeURIComponent(filter)}`);
     if (from !== undefined) parts.push(`from=${encodeURIComponent(from)}`);
     if (to !== undefined) parts.push(`to=${encodeURIComponent(to)}`);
+    if (limit !== undefined) parts.push(`limit=${limit}`);
 
     return parts.join(":");
   }

--- a/src/providers/archive-it.ts
+++ b/src/providers/archive-it.ts
@@ -31,7 +31,7 @@ export class ArchiveItProvider extends BaseProvider<ArchiveItOptions> {
     const filter = requestOptions?.filter ?? this.options.filter;
     const from = requestOptions?.from ?? this.options.from;
     const to = requestOptions?.to ?? this.options.to;
-    const limit = requestOptions?.limit ?? this.options.limit;
+    const limit = requestOptions?.limit === undefined ? this.options.limit : undefined;
     const parts = [`collection=${encodeURIComponent(collection)}`];
 
     if (collapse !== undefined) parts.push(`collapse=${encodeURIComponent(collapse)}`);

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,6 +1,7 @@
 import type { ArchiveOptions, ArchiveProvider } from "../types";
 import type {
   WaybackOptions,
+  ArchiveItOptions,
   ArchiveTodayOptions,
   PermaccOptions,
   CommonCrawlOptions,
@@ -24,6 +25,20 @@ export const providers = {
   async wayback(options?: WaybackOptions): Promise<ArchiveProvider> {
     const { WaybackProvider } = await import("./wayback");
     return new WaybackProvider(options);
+  },
+
+  /**
+   * Creates an Archive-It provider for one collection.
+   * @param options - Configuration including the required Archive-It collection ID
+   * @returns The Archive-It provider
+   * @example
+   * ```js
+   * const archiveItProvider = providers.archiveIt({ collection: 4399 })
+   * ```
+   */
+  async archiveIt(options: ArchiveItOptions): Promise<ArchiveProvider> {
+    const { ArchiveItProvider } = await import("./archive-it");
+    return new ArchiveItProvider(options);
   },
 
   /**
@@ -84,7 +99,7 @@ export const providers = {
 
   /**
    * Helper to initialize all commonly used providers at once.
-   * Note: Perma.cc is excluded as it requires an API key.
+   * Note: Archive-It is excluded because it requires a collection ID; Perma.cc requires an API key.
    * @param options - Common configuration options for all providers
    * @returns An array of all common providers
    * @example
@@ -99,7 +114,7 @@ export const providers = {
       this.archiveToday(options),
       this.commoncrawl(options),
       this.webcite(options),
-      // permacc excluded as it requires API key
+      // Archive-It requires a collection ID; Perma.cc requires an API key.
     ]);
   },
 };

--- a/test/archive-it.test.ts
+++ b/test/archive-it.test.ts
@@ -24,6 +24,12 @@ describe("Archive-It", () => {
     );
   });
 
+  it("does not duplicate a request limit in its provider cache key", () => {
+    expect(createArchiveIt({ collection: 4399, limit: 25 }).cacheKey({ limit: 10 })).toBe(
+      "collection=4399",
+    );
+  });
+
   it("lists pages from a collection CDX index", async () => {
     vi.mocked($fetch).mockResolvedValueOnce(
       [

--- a/test/archive-it.test.ts
+++ b/test/archive-it.test.ts
@@ -18,6 +18,12 @@ describe("Archive-It", () => {
     expect(createArchiveIt({ collection: " 4399 " }).cacheKey()).toBe("collection=4399");
   });
 
+  it("includes the provider init limit in its cache key", () => {
+    expect(createArchiveIt({ collection: 4399, limit: 25 }).cacheKey()).toBe(
+      "collection=4399:limit=25",
+    );
+  });
+
   it("lists pages from a collection CDX index", async () => {
     vi.mocked($fetch).mockResolvedValueOnce(
       [

--- a/test/archive-it.test.ts
+++ b/test/archive-it.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { $fetch } from "ofetch";
+import { createArchive, resetConfig, storage } from "../src";
+import createArchiveIt from "../src/providers/archive-it";
+
+vi.mock("ofetch", () => ({
+  $fetch: vi.fn(),
+}));
+
+describe("Archive-It", () => {
+  beforeEach(async () => {
+    await storage.clear();
+    resetConfig();
+    vi.resetAllMocks();
+  });
+
+  it("normalizes collection whitespace in cache keys", () => {
+    expect(createArchiveIt({ collection: " 4399 " }).cacheKey()).toBe("collection=4399");
+  });
+
+  it("lists pages from a collection CDX index", async () => {
+    vi.mocked($fetch).mockResolvedValueOnce(
+      [
+        "https://example.com/ 20220101000000 200",
+        "https://example.com/page 20220201000000 404",
+      ].join("\n"),
+    );
+
+    const archive = createArchive(createArchiveIt({ collection: 4399 }));
+    const result = await archive.snapshots("example.com", { limit: 2 });
+
+    expect(result.success).toBe(true);
+    expect(result.pages).toHaveLength(2);
+    expect(result.pages[0]).toMatchObject({
+      url: "https://example.com/",
+      timestamp: "2022-01-01T00:00:00Z",
+      snapshot: "https://wayback.archive-it.org/4399/20220101000000/https://example.com/",
+      _meta: {
+        timestamp: "20220101000000",
+        status: 200,
+        provider: "archive-it",
+      },
+    });
+    expect(result._meta).toMatchObject({ source: "archive-it", collection: "4399" });
+    expect($fetch).toHaveBeenCalledWith(
+      "/4399/timemap/cdx",
+      expect.objectContaining({
+        baseURL: "https://wayback.archive-it.org",
+        responseType: "text",
+        params: expect.objectContaining({
+          url: "example.com/*",
+          fl: "original,timestamp,statuscode",
+          limit: "2",
+        }),
+      }),
+    );
+  });
+
+  it("passes collection-specific CDX filters", async () => {
+    vi.mocked($fetch).mockResolvedValueOnce("");
+
+    const archive = createArchive(
+      createArchiveIt({
+        collection: "4399",
+        collapse: "timestamp:10",
+        filter: "statuscode:200",
+        from: "2020",
+        to: "2024",
+      }),
+    );
+    await archive.snapshots("https://example.com/page");
+
+    expect($fetch).toHaveBeenCalledWith(
+      "/4399/timemap/cdx",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          url: "example.com/page/*",
+          collapse: "timestamp:10",
+          filter: "statuscode:200",
+          from: "2020",
+          to: "2024",
+        }),
+      }),
+    );
+  });
+
+  it("returns an empty success response for an empty CDX result", async () => {
+    vi.mocked($fetch).mockResolvedValueOnce("");
+
+    const result = await createArchive(createArchiveIt({ collection: 4399 })).snapshots(
+      "missing.example",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.pages).toEqual([]);
+  });
+
+  it("rejects a non-numeric collection ID without making a request", async () => {
+    const result = await createArchive(createArchiveIt({ collection: "all" })).snapshots(
+      "example.com",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Archive-It collection must be a numeric collection ID");
+    expect($fetch).not.toHaveBeenCalled();
+  });
+});

--- a/test/omp-extension.test.ts
+++ b/test/omp-extension.test.ts
@@ -1,7 +1,12 @@
 import * as TypeBox from "@oh-my-pi/omptype/typebox";
+import { $fetch } from "ofetch";
 import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "@oh-my-pi/pi-coding-agent";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import archivesOmpExtension from "../packages/omp/extensions/archives.js";
+
+vi.mock("ofetch", () => ({
+  $fetch: vi.fn(),
+}));
 
 class TestText {
   constructor(private readonly text: string) {}
@@ -54,6 +59,10 @@ function accepts(tool: ToolDefinition, value: unknown): boolean {
 const unusedContext = {} as ExtensionContext;
 
 describe("archives OMP extension", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
   it("registers read-only tools and interactive commands", () => {
     const { label, tools, commands } = registerExtension();
 
@@ -72,6 +81,43 @@ describe("archives OMP extension", () => {
     expect(accepts(tool, { target: "example.com", retries: 0.5 })).toBe(false);
     expect(accepts(tool, { target: "example.com", ttl: 0.5 })).toBe(false);
     expect(accepts(tool, { target: "example.com", timeout: 1.5 })).toBe(false);
+  });
+
+  it("dispatches Archive-It requests with the required collection", async () => {
+    vi.mocked($fetch).mockResolvedValueOnce("https://example.com/ 20220101000000 200");
+    const tool = requireTool(registerExtension().tools, "archives");
+
+    const result = await tool.execute(
+      "test",
+      { target: "example.com", provider: "archiveIt", collection: " 4399 ", cache: false },
+      undefined,
+      undefined,
+      unusedContext,
+    );
+
+    expect($fetch).toHaveBeenCalledWith(
+      "/4399/timemap/cdx",
+      expect.objectContaining({ baseURL: "https://wayback.archive-it.org" }),
+    );
+    expect(result.details).toMatchObject({
+      provider: "archiveIt",
+      response: { success: true, _meta: { provider: "archive-it" } },
+    });
+  });
+
+  it("rejects Archive-It requests without a collection", async () => {
+    const tool = requireTool(registerExtension().tools, "archives");
+
+    await expect(
+      tool.execute(
+        "test",
+        { target: "example.com", provider: "archiveIt" },
+        undefined,
+        undefined,
+        unusedContext,
+      ),
+    ).rejects.toThrow("provider=archiveIt requires a numeric collection id");
+    expect($fetch).not.toHaveBeenCalled();
   });
 
   it("removes terminal control bytes from rendered untrusted arguments", () => {
@@ -104,6 +150,7 @@ describe("archives OMP extension", () => {
     const text = result.content.find((part) => part.type === "text")?.text;
 
     expect(text).toContain("wayback");
+    expect(text).toContain("archiveIt");
     expect(text).toContain("permacc");
   });
 });

--- a/test/pi-extension.test.ts
+++ b/test/pi-extension.test.ts
@@ -1,157 +1,214 @@
 import type {
-	AgentToolResult,
-	ExtensionAPI,
-	ExtensionCommandContext,
-	ExtensionContext,
-	ToolDefinition,
+  AgentToolResult,
+  ExtensionAPI,
+  ExtensionCommandContext,
+  ExtensionContext,
+  ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import archivesExtension from "../packages/pi/extensions/archives";
 import type { ArchiveResponse } from "../src/types";
 
 const archivesMock = vi.hoisted(() => ({
-	snapshots: vi.fn(),
+  archiveIt: vi.fn(),
+  snapshots: vi.fn(),
 }));
 
 vi.mock("@agntn/archives", () => ({
-	createArchive: () => ({ snapshots: archivesMock.snapshots }),
-	providers: {
-		wayback: async () => ({ name: "Internet Archive Wayback Machine", slug: "wayback", snapshots: archivesMock.snapshots }),
-	},
+  createArchive: () => ({ snapshots: archivesMock.snapshots }),
+  providers: {
+    wayback: async () => ({
+      name: "Internet Archive Wayback Machine",
+      slug: "wayback",
+      snapshots: archivesMock.snapshots,
+    }),
+    archiveIt: archivesMock.archiveIt,
+  },
 }));
 
 type CommandDefinition = Parameters<ExtensionAPI["registerCommand"]>[1];
 
 type CapturedRuntime = {
-	tools: Map<string, ToolDefinition>;
-	commands: Map<string, CommandDefinition>;
+  tools: Map<string, ToolDefinition>;
+  commands: Map<string, CommandDefinition>;
 };
 
 type ExecutableTool = {
-	parameters: { properties?: Record<string, unknown> };
-	execute: (
-		toolCallId: string,
-		params: Record<string, unknown>,
-		signal: AbortSignal | undefined,
-		onUpdate: undefined,
-		ctx: ExtensionContext,
-	) => Promise<AgentToolResult<unknown>>;
+  parameters: { properties?: Record<string, unknown> };
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal: AbortSignal | undefined,
+    onUpdate: undefined,
+    ctx: ExtensionContext,
+  ) => Promise<AgentToolResult<unknown>>;
 };
 
 function loadExtension(): CapturedRuntime {
-	const runtime: CapturedRuntime = {
-		tools: new Map(),
-		commands: new Map(),
-	};
-	const pi = {
-		registerTool(tool: ToolDefinition) {
-			runtime.tools.set(tool.name, tool);
-		},
-		registerCommand(name: string, command: CommandDefinition) {
-			runtime.commands.set(name, command);
-		},
-	} satisfies Partial<ExtensionAPI>;
+  const runtime: CapturedRuntime = {
+    tools: new Map(),
+    commands: new Map(),
+  };
+  const pi = {
+    registerTool(tool: ToolDefinition) {
+      runtime.tools.set(tool.name, tool);
+    },
+    registerCommand(name: string, command: CommandDefinition) {
+      runtime.commands.set(name, command);
+    },
+  } satisfies Partial<ExtensionAPI>;
 
-	archivesExtension(pi as ExtensionAPI);
-	return runtime;
+  archivesExtension(pi as ExtensionAPI);
+  return runtime;
 }
 
 function getExecutableTool(runtime: CapturedRuntime, name: string): ExecutableTool {
-	const tool = runtime.tools.get(name);
-	expect(tool).toBeDefined();
-	return tool as ExecutableTool;
+  const tool = runtime.tools.get(name);
+  expect(tool).toBeDefined();
+  return tool as ExecutableTool;
 }
 
 const originalPermaccEnv = {
-	PERMA_CC_API_KEY: process.env["PERMA_CC_API_KEY"],
-	PERMACC_API_KEY: process.env["PERMACC_API_KEY"],
+  PERMA_CC_API_KEY: process.env["PERMA_CC_API_KEY"],
+  PERMACC_API_KEY: process.env["PERMACC_API_KEY"],
 };
 
 function restoreEnv(name: keyof typeof originalPermaccEnv): void {
-	const value = originalPermaccEnv[name];
-	if (value === undefined) {
-		delete process.env[name];
-		return;
-	}
-	process.env[name] = value;
+  const value = originalPermaccEnv[name];
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
 }
 
 describe("Pi extension", () => {
-	beforeEach(() => {
-		archivesMock.snapshots.mockReset();
-	});
+  beforeEach(() => {
+    archivesMock.snapshots.mockReset();
+    archivesMock.archiveIt.mockReset();
+  });
 
-	afterEach(() => {
-		restoreEnv("PERMA_CC_API_KEY");
-		restoreEnv("PERMACC_API_KEY");
-	});
+  afterEach(() => {
+    restoreEnv("PERMA_CC_API_KEY");
+    restoreEnv("PERMACC_API_KEY");
+  });
 
-	it("registers the expected tools and commands", () => {
-		const runtime = loadExtension();
+  it("registers the expected tools and commands", () => {
+    const runtime = loadExtension();
 
-		expect([...runtime.tools.keys()].sort()).toEqual(["archives", "archives_providers"]);
-		expect([...runtime.commands.keys()].sort()).toEqual(["archive", "archive-providers"]);
-	});
+    expect([...runtime.tools.keys()].sort()).toEqual(["archives", "archives_providers"]);
+    expect([...runtime.commands.keys()].sort()).toEqual(["archive", "archive-providers"]);
+  });
 
-	it("does not expose arbitrary API-key or environment-variable parameters", () => {
-		const runtime = loadExtension();
-		const tool = getExecutableTool(runtime, "archives");
+  it("does not expose arbitrary API-key or environment-variable parameters", () => {
+    const runtime = loadExtension();
+    const tool = getExecutableTool(runtime, "archives");
 
-		expect(Object.keys(tool.parameters.properties ?? {})).not.toContain("apiKey");
-		expect(Object.keys(tool.parameters.properties ?? {})).not.toContain("apiKeyEnv");
-	});
+    expect(Object.keys(tool.parameters.properties ?? {})).not.toContain("apiKey");
+    expect(Object.keys(tool.parameters.properties ?? {})).not.toContain("apiKeyEnv");
+  });
 
-	it("reports Perma.cc key presence without returning the secret value", async () => {
-		process.env["PERMA_CC_API_KEY"] = "super-secret-test-key";
-		const runtime = loadExtension();
-		const tool = getExecutableTool(runtime, "archives_providers");
+  it("reports Perma.cc key presence without returning the secret value", async () => {
+    process.env["PERMA_CC_API_KEY"] = "super-secret-test-key";
+    const runtime = loadExtension();
+    const tool = getExecutableTool(runtime, "archives_providers");
 
-		const result = await tool.execute("test", {}, undefined, undefined, {} as ExtensionContext);
-		const text = result.content.map((item) => (item.type === "text" ? item.text : "")).join("\n");
+    const result = await tool.execute("test", {}, undefined, undefined, {} as ExtensionContext);
+    const text = result.content.map((item) => (item.type === "text" ? item.text : "")).join("\n");
+    expect(text).toContain("archiveIt");
 
-		expect(text).toContain("PERMA_CC_API_KEY is set");
-		expect(text).not.toContain("super-secret-test-key");
-	});
+    expect(text).toContain("PERMA_CC_API_KEY is set");
+    expect(text).not.toContain("super-secret-test-key");
+  });
 
-	it("fails Perma.cc requests before network work when no fixed API-key env var is set", async () => {
-		delete process.env["PERMA_CC_API_KEY"];
-		delete process.env["PERMACC_API_KEY"];
-		const runtime = loadExtension();
-		const tool = getExecutableTool(runtime, "archives");
+  it("fails Perma.cc requests before network work when no fixed API-key env var is set", async () => {
+    delete process.env["PERMA_CC_API_KEY"];
+    delete process.env["PERMACC_API_KEY"];
+    const runtime = loadExtension();
+    const tool = getExecutableTool(runtime, "archives");
 
-		await expect(
-			tool.execute("test", { target: "example.com", provider: "permacc" }, undefined, undefined, {} as ExtensionContext),
-		).rejects.toThrow("Perma.cc provider requires an API key in PERMA_CC_API_KEY or PERMACC_API_KEY");
-	});
+    await expect(
+      tool.execute(
+        "test",
+        { target: "example.com", provider: "permacc" },
+        undefined,
+        undefined,
+        {} as ExtensionContext,
+      ),
+    ).rejects.toThrow(
+      "Perma.cc provider requires an API key in PERMA_CC_API_KEY or PERMACC_API_KEY",
+    );
+  });
 
-	it("reports /archive API errors instead of showing an empty-result warning", async () => {
-		const response = {
-			success: false,
-			pages: [],
-			error: "Wayback unavailable",
-			_meta: { source: "wayback", provider: "wayback" },
-		} satisfies ArchiveResponse;
-		archivesMock.snapshots.mockResolvedValue(response);
-		const runtime = loadExtension();
-		const command = runtime.commands.get("archive");
-		if (!command) throw new Error("archive command was not registered");
-		const notify = vi.fn();
-		const select = vi.fn();
-		const pasteToEditor = vi.fn();
-		const ctx = {
-			hasUI: true,
-			ui: {
-				input: vi.fn(),
-				notify,
-				select,
-				pasteToEditor,
-			},
-		} as unknown as ExtensionCommandContext;
+  it("dispatches Archive-It requests with the required collection", async () => {
+    archivesMock.archiveIt.mockResolvedValue({
+      name: "Archive-It",
+      slug: "archive-it",
+      snapshots: archivesMock.snapshots,
+    });
+    archivesMock.snapshots.mockResolvedValue({
+      success: true,
+      pages: [],
+      _meta: { source: "archive-it", provider: "archive-it" },
+    } satisfies ArchiveResponse);
+    const tool = getExecutableTool(loadExtension(), "archives");
 
-		await command.handler("example.com", ctx);
+    await tool.execute(
+      "test",
+      { target: "example.com", provider: "archiveIt", collection: " 4399 " },
+      undefined,
+      undefined,
+      {} as ExtensionContext,
+    );
 
-		expect(notify).toHaveBeenCalledWith("archives failed: Wayback unavailable", "error");
-		expect(select).not.toHaveBeenCalled();
-		expect(pasteToEditor).not.toHaveBeenCalled();
-	});
+    expect(archivesMock.archiveIt).toHaveBeenCalledWith(
+      expect.objectContaining({ collection: "4399" }),
+    );
+  });
+
+  it("rejects Archive-It requests without a collection", async () => {
+    const tool = getExecutableTool(loadExtension(), "archives");
+
+    await expect(
+      tool.execute(
+        "test",
+        { target: "example.com", provider: "archiveIt" },
+        undefined,
+        undefined,
+        {} as ExtensionContext,
+      ),
+    ).rejects.toThrow("provider=archiveIt requires a numeric collection id");
+    expect(archivesMock.archiveIt).not.toHaveBeenCalled();
+  });
+
+  it("reports /archive API errors instead of showing an empty-result warning", async () => {
+    const response = {
+      success: false,
+      pages: [],
+      error: "Wayback unavailable",
+      _meta: { source: "wayback", provider: "wayback" },
+    } satisfies ArchiveResponse;
+    archivesMock.snapshots.mockResolvedValue(response);
+    const runtime = loadExtension();
+    const command = runtime.commands.get("archive");
+    if (!command) throw new Error("archive command was not registered");
+    const notify = vi.fn();
+    const select = vi.fn();
+    const pasteToEditor = vi.fn();
+    const ctx = {
+      hasUI: true,
+      ui: {
+        input: vi.fn(),
+        notify,
+        select,
+        pasteToEditor,
+      },
+    } as unknown as ExtensionCommandContext;
+
+    await command.handler("example.com", ctx);
+
+    expect(notify).toHaveBeenCalledWith("archives failed: Wayback unavailable", "error");
+    expect(select).not.toHaveBeenCalled();
+    expect(pasteToEditor).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Archive-It is still alive, but `/all` is temporarily blocked, so this adds collection-specific CDX/C queries instead of pretending it can be part of `providers.all()`. The provider requires a numeric collection ID and is wired into the library, Pi and OMP surfaces. Checked against live collection 8232.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/agntn/archives/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

