### PR TITLE
fix: cancel archive requests with tool calls

### DIFF
--- a/packages/omp/extensions/archives.ts
+++ b/packages/omp/extensions/archives.ts
@@ -238,9 +238,9 @@ export default function archivesOmpExtension(pi: ExtensionAPI) {
     renderCall(args, _options, theme) {
       return new Text(renderSnapshotCall(args, theme), 0, 0);
     },
-    async execute(_toolCallId, params) {
+    async execute(_toolCallId, params, signal) {
       const { snapshotArchives } = await loadToolOperations();
-      return snapshotArchives(params);
+      return snapshotArchives(params, signal);
     },
   });
 
@@ -254,9 +254,9 @@ export default function archivesOmpExtension(pi: ExtensionAPI) {
     renderCall(args, _options, theme) {
       return new Text(renderContentCall(args, theme), 0, 0);
     },
-    async execute(_toolCallId, params) {
+    async execute(_toolCallId, params, signal) {
       const { contentArchives } = await loadToolOperations();
-      return contentArchives(params);
+      return contentArchives(params, signal);
     },
   });
 

--- a/packages/pi/extensions/archives.ts
+++ b/packages/pi/extensions/archives.ts
@@ -245,9 +245,9 @@ export default function archivesExtension(pi: ExtensionAPI) {
     renderCall(args, theme) {
       return new Text(renderSnapshotCall(args, theme), 0, 0);
     },
-    async execute(_toolCallId, params): Promise<AgentToolResult<SnapshotDetails>> {
+    async execute(_toolCallId, params, signal): Promise<AgentToolResult<SnapshotDetails>> {
       const { snapshotArchives } = await loadToolOperations();
-      return snapshotArchives(params);
+      return snapshotArchives(params, signal);
     },
   });
 
@@ -268,9 +268,9 @@ export default function archivesExtension(pi: ExtensionAPI) {
     renderCall(args, theme) {
       return new Text(renderContentCall(args, theme), 0, 0);
     },
-    async execute(_toolCallId, params): Promise<AgentToolResult<ContentDetails>> {
+    async execute(_toolCallId, params, signal): Promise<AgentToolResult<ContentDetails>> {
       const { contentArchives } = await loadToolOperations();
-      return contentArchives(params);
+      return contentArchives(params, signal);
     },
   });
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -40,7 +40,10 @@ interface ToolDefinition {
   description: string;
   inputSchema: TSchema;
   annotations: Tool["annotations"];
-  execute(args: Record<string, unknown>): ToolResult<unknown> | Promise<ToolResult<unknown>>;
+  execute(
+    args: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): ToolResult<unknown> | Promise<ToolResult<unknown>>;
 }
 
 const tools: ToolDefinition[] = [
@@ -141,7 +144,7 @@ const tools: ToolDefinition[] = [
       idempotentHint: false,
       openWorldHint: true,
     },
-    execute: (args) => snapshotArchives(args as unknown as SnapshotParams),
+    execute: (args, signal) => snapshotArchives(args as unknown as SnapshotParams, signal),
   },
   {
     name: "archives_content",
@@ -221,7 +224,7 @@ const tools: ToolDefinition[] = [
       idempotentHint: false,
       openWorldHint: true,
     },
-    execute: (args) => contentArchives(args as unknown as ContentParams),
+    execute: (args, signal) => contentArchives(args as unknown as ContentParams, signal),
   },
   {
     name: "archives_providers",
@@ -322,7 +325,7 @@ export function createMcpServer(): Server {
     })),
   }));
 
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     const tool = toolsByName.get(request.params.name);
     if (!tool) return errorResult(`Unknown archives tool: ${request.params.name}`);
 
@@ -332,7 +335,7 @@ export function createMcpServer(): Server {
     }
 
     try {
-      return toCallToolResult(await tool.execute(args));
+      return toCallToolResult(await tool.execute(args, extra.signal));
     } catch (error) {
       return errorResult(
         `${tool.name} failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/providers/archive-it.ts
+++ b/src/providers/archive-it.ts
@@ -93,6 +93,7 @@ export class ArchiveItProvider extends BaseProvider<ArchiveItOptions> {
 
       const fetchOptions = await createFetchOptions(baseUrl, params, {
         retries: options.retries,
+        signal: options.signal,
         timeout: options.timeout,
       });
       const response: string = await $fetch(`/${collection}/timemap/cdx`, {
@@ -193,6 +194,7 @@ export class ArchiveItProvider extends BaseProvider<ArchiveItOptions> {
 
     const fetchOptions = await createFetchOptions(BASE_URL, params, {
       retries: options.retries,
+      signal: options.signal,
       timeout: options.timeout,
     });
     const response: string = await $fetch(`/${collection}/timemap/cdx`, {

--- a/src/providers/archive-today.ts
+++ b/src/providers/archive-today.ts
@@ -42,6 +42,7 @@ export class ArchiveTodayProvider extends BaseProvider<ArchiveTodayOptions> {
 
       const timemapResponse = await $fetch(timemapUrl, {
         baseURL,
+        signal: options.signal,
         retry: options.retries ?? 5,
         timeout: options.timeout ?? 60000,
         responseType: "text",

--- a/src/providers/commoncrawl.ts
+++ b/src/providers/commoncrawl.ts
@@ -99,6 +99,7 @@ export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
 
       const fetchOptions = await createFetchOptions(BASE_URL, params, {
         retries: options.retries,
+        signal: options.signal,
         timeout: options.timeout ?? 60_000,
         responseType: "text",
       });
@@ -250,6 +251,7 @@ export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
         {},
         {
           retries: options.retries,
+          signal: options.signal,
           timeout: options.timeout ?? 60_000,
         },
       );
@@ -311,6 +313,7 @@ export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
 
     const fetchOptions = await createFetchOptions(BASE_URL, params, {
       retries: options.retries,
+      signal: options.signal,
       timeout: options.timeout ?? 60_000,
       responseType: "text",
     });
@@ -361,6 +364,7 @@ export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
       {
         responseType: "stream",
         retries: options.retries,
+        signal: options.signal,
         timeout: options.timeout ?? 60_000,
         headers: { range: `bytes=${start}-${start + length - 1}` },
       },

--- a/src/providers/permacc.ts
+++ b/src/providers/permacc.ts
@@ -176,6 +176,7 @@ export class PermaccProvider extends BaseProvider<PermaccOptions> {
             Authorization: `ApiKey ${apiKey}`,
           },
           retries: options.retries,
+          signal: options.signal,
           timeout: options.timeout,
         },
       );

--- a/src/providers/wayback.ts
+++ b/src/providers/wayback.ts
@@ -74,6 +74,7 @@ export class WaybackProvider extends BaseProvider<WaybackOptions> {
 
       const fetchOptions = await createFetchOptions(baseUrl, params, {
         retries: options.retries,
+        signal: options.signal,
         timeout: options.timeout,
       });
 
@@ -178,6 +179,7 @@ export class WaybackProvider extends BaseProvider<WaybackOptions> {
   ): Promise<CdxCapture[]> {
     const fetchOptions = await createFetchOptions(BASE_URL, params, {
       retries: options.retries,
+      signal: options.signal,
       timeout: options.timeout,
     });
 

--- a/src/tool-operations.ts
+++ b/src/tool-operations.ts
@@ -96,7 +96,7 @@ export type SnapshotOptions = ArchiveOptions & {
 };
 
 /** Snapshot options as they reach a harness transcript: never carrying the key. */
-export type RedactedSnapshotOptions = Omit<SnapshotOptions, "apiKey"> & {
+export type RedactedSnapshotOptions = Omit<SnapshotOptions, "apiKey" | "signal"> & {
   apiKey?: "<redacted>";
 };
 
@@ -107,7 +107,7 @@ export type ContentOptions = ArchiveContentOptions & {
 };
 
 /** Content options as they reach a harness transcript: never carrying the key. */
-export type RedactedContentOptions = Omit<ContentOptions, "apiKey"> & {
+export type RedactedContentOptions = Omit<ContentOptions, "apiKey" | "signal"> & {
   apiKey?: "<redacted>";
 };
 
@@ -194,6 +194,7 @@ interface PermaccApiKeyState {
  */
 export async function snapshotArchives(
   params: SnapshotParams,
+  signal?: AbortSignal,
 ): Promise<ToolResult<SnapshotDetails>> {
   const target = params.target.trim();
   if (!target) {
@@ -204,7 +205,7 @@ export async function snapshotArchives(
   }
 
   const provider = normalizeProvider(params.provider);
-  const options = buildSnapshotOptions(params, provider);
+  const options = { ...buildSnapshotOptions(params, provider), signal };
   const archiveProvider = await createProvider(provider, options);
   const archive = createArchive(archiveProvider, options);
   const response = await archive.snapshots(target, options);
@@ -247,7 +248,10 @@ export async function snapshotArchives(
  * @throws When the target is empty, an argument is out of range, the provider is
  * unknown, or its prerequisites are missing
  */
-export async function contentArchives(params: ContentParams): Promise<ToolResult<ContentDetails>> {
+export async function contentArchives(
+  params: ContentParams,
+  signal?: AbortSignal,
+): Promise<ToolResult<ContentDetails>> {
   const target = params.target.trim();
   if (!target) {
     throw new Error("Target cannot be empty");
@@ -259,7 +263,7 @@ export async function contentArchives(params: ContentParams): Promise<ToolResult
   const provider = normalizeProvider(params.provider);
   const format = normalizeFormat(params.format);
   const maxChars = params.maxChars ?? DEFAULT_MAX_CHARS;
-  const options = await buildContentOptions(params, provider, format, maxChars);
+  const options = { ...(await buildContentOptions(params, provider, format, maxChars)), signal };
   const archiveProvider = await createProvider(provider, options);
   const archive = createArchive(archiveProvider, options);
   const response = await archive.content(target, options);
@@ -500,11 +504,11 @@ async function buildContentOptions(
   return options;
 }
 
-/** Strips the Perma.cc key before options reach a transcript or a tool result. */
-export function redactOptions<TOptions extends { apiKey?: string }>(
+/** Strips private runtime state before options reach a transcript or a tool result. */
+export function redactOptions<TOptions extends { apiKey?: string; signal?: AbortSignal }>(
   options: TOptions,
-): Omit<TOptions, "apiKey"> & { apiKey?: "<redacted>" } {
-  const { apiKey: _apiKey, ...rest } = options;
+): Omit<TOptions, "apiKey" | "signal"> & { apiKey?: "<redacted>" } {
+  const { apiKey: _apiKey, signal: _signal, ...rest } = options;
   return options.apiKey ? { ...rest, apiKey: "<redacted>" } : rest;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export interface ArchiveOptions {
   // Pagination option
   limit?: number; // Maximum number of results to return
+  signal?: AbortSignal; // Cancels in-flight provider requests
 
   // Caching options
   cache?: boolean; // Enable/disable caching

--- a/src/utils/_content.ts
+++ b/src/utils/_content.ts
@@ -305,6 +305,7 @@ export async function fetchBody(
     {
       responseType: "stream",
       retries: options.retries,
+      signal: options.signal,
       timeout: options.timeout,
       ...(options.headers ? { headers: options.headers } : {}),
     },

--- a/src/utils/_utils.ts
+++ b/src/utils/_utils.ts
@@ -330,6 +330,7 @@ export async function createFetchOptions(
     params,
     retry: options.retries ?? config.performance.retries,
     timeout: options.timeout ?? config.performance.timeout,
+    signal: options.signal,
     retryDelay: 300, // Add delay between retries
     retryStatusCodes: [408, 409, 425, 429, 500, 502, 503, 504], // Standard retry status codes
     onResponseError: ({ request, response, options }) => {

--- a/test/archive-today.test.ts
+++ b/test/archive-today.test.ts
@@ -28,7 +28,8 @@ describe("archive.today", () => {
 
     const archiveInstance = createArchiveToday();
     const archive = createArchiveClient(archiveInstance);
-    const result = await archive.snapshots("example.com");
+    const controller = new AbortController();
+    const result = await archive.snapshots("example.com", { signal: controller.signal });
 
     expect(result.success).toBe(true);
     expect(result.pages).toHaveLength(4);
@@ -44,6 +45,7 @@ describe("archive.today", () => {
       "/timemap/http://example.com",
       expect.objectContaining({
         baseURL: "https://archive.is",
+        signal: controller.signal,
         responseType: "text",
         retry: 1,
         timeout: 10000,

--- a/test/pi-extension.test.ts
+++ b/test/pi-extension.test.ts
@@ -222,12 +222,17 @@ describe("Pi extension", () => {
     archivesMock.snapshots.mockImplementation(
       (_target: string, options: { signal?: AbortSignal }) =>
         new Promise<ArchiveResponse>((_resolve, reject) => {
-          const abort = () => reject(options.signal?.reason ?? new Error("cancelled"));
-          if (options.signal?.aborted) {
+          const signal = options.signal;
+          if (!signal) {
+            reject(new Error("missing AbortSignal"));
+            return;
+          }
+          const abort = () => reject(signal.reason ?? new Error("cancelled"));
+          if (signal.aborted) {
             abort();
             return;
           }
-          options.signal?.addEventListener("abort", abort, { once: true });
+          signal.addEventListener("abort", abort, { once: true });
         }),
     );
     const tool = getExecutableTool(loadExtension(), "archives");
@@ -239,6 +244,14 @@ describe("Pi extension", () => {
       controller.signal,
       undefined,
       {} as ExtensionContext,
+    );
+    await vi.waitFor(
+      () =>
+        expect(archivesMock.snapshots).toHaveBeenCalledWith(
+          "example.com",
+          expect.objectContaining({ signal: controller.signal }),
+        ),
+      { timeout: 100 },
     );
     controller.abort(new Error("cancelled by test"));
 

--- a/test/pi-extension.test.ts
+++ b/test/pi-extension.test.ts
@@ -218,26 +218,34 @@ describe("Pi extension", () => {
     expect(archivesMock.content).not.toHaveBeenCalled();
   });
 
-  it("passes tool cancellation to archive requests", async () => {
-    archivesMock.snapshots.mockResolvedValue({
-      success: true,
-      pages: [],
-      _meta: { source: "wayback", provider: "wayback" },
-    } satisfies ArchiveResponse);
+  it("stops an in-flight archive request when the tool is cancelled", async () => {
+    archivesMock.snapshots.mockImplementation(
+      (_target: string, options: { signal?: AbortSignal }) =>
+        new Promise<ArchiveResponse>((_resolve, reject) => {
+          const abort = () => reject(options.signal?.reason ?? new Error("cancelled"));
+          if (options.signal?.aborted) {
+            abort();
+            return;
+          }
+          options.signal?.addEventListener("abort", abort, { once: true });
+        }),
+    );
     const tool = getExecutableTool(loadExtension(), "archives");
     const controller = new AbortController();
 
-    const result = await tool.execute(
+    const execution = tool.execute(
       "test",
       { target: "example.com", provider: "wayback", cache: false },
       controller.signal,
       undefined,
       {} as ExtensionContext,
     );
+    controller.abort(new Error("cancelled by test"));
 
-    expect(archivesMock.snapshots).toHaveBeenCalledWith(
-      "example.com",
-      expect.objectContaining({ signal: controller.signal }),
+    const result = await execution;
+    expect(result.isError).toBe(true);
+    expect(result.content[0]).toEqual(
+      expect.objectContaining({ type: "text", text: expect.stringContaining("cancelled by test") }),
     );
     expect((result.details as { options: Record<string, unknown> }).options).not.toHaveProperty(
       "signal",

--- a/test/pi-extension.test.ts
+++ b/test/pi-extension.test.ts
@@ -218,6 +218,31 @@ describe("Pi extension", () => {
     expect(archivesMock.content).not.toHaveBeenCalled();
   });
 
+  it("passes tool cancellation to archive requests", async () => {
+    archivesMock.snapshots.mockResolvedValue({
+      success: true,
+      pages: [],
+      _meta: { source: "wayback", provider: "wayback" },
+    } satisfies ArchiveResponse);
+    const tool = getExecutableTool(loadExtension(), "archives");
+    const controller = new AbortController();
+
+    const result = await tool.execute(
+      "test",
+      { target: "example.com", provider: "wayback", cache: false },
+      controller.signal,
+      undefined,
+      {} as ExtensionContext,
+    );
+
+    expect(archivesMock.snapshots).toHaveBeenCalledWith(
+      "example.com",
+      expect.objectContaining({ signal: controller.signal }),
+    );
+    expect((result.details as { options: Record<string, unknown> }).options).not.toHaveProperty(
+      "signal",
+    );
+  });
   it("declares the schema bounds the shared executors enforce", () => {
     const tool = getExecutableTool(loadExtension(), "archives");
     const properties = tool.parameters.properties as Record<string, Record<string, unknown>>;

--- a/test/wayback.test.ts
+++ b/test/wayback.test.ts
@@ -26,7 +26,8 @@ describe("wayback machine", () => {
 
     const waybackInstance = createWayback();
     const archive = createArchive(waybackInstance);
-    const result = await archive.snapshots("example.com");
+    const controller = new AbortController();
+    const result = await archive.snapshots("example.com", { signal: controller.signal });
 
     expect(result.success).toBe(true);
     expect(result.pages).toHaveLength(2);
@@ -47,6 +48,7 @@ describe("wayback machine", () => {
       "/cdx/search/cdx",
       expect.objectContaining({
         baseURL: "https://web.archive.org",
+        signal: controller.signal,
         method: "GET",
       }),
     );


### PR DESCRIPTION
Stopping an archives tool didn't stop its network request, so slow providers kept running until timeout. This wires the Pi, OMP and MCP abort signal through the shared executors into ofetch, without leaking runtime state into tool details.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/agntn/archives/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

