### PR TITLE
fix: fall back to snapshot stamp for unreadable memento dates

### DIFF
--- a/src/providers/archive-today.ts
+++ b/src/providers/archive-today.ts
@@ -14,6 +14,7 @@ import {
   createErrorResponse,
   createUnsupportedContentResponse,
   normalizeDomain,
+  waybackTimestampToISO,
 } from "../utils";
 import { BaseProvider } from "./base-provider";
 
@@ -29,6 +30,11 @@ export class ArchiveTodayProvider extends BaseProvider<ArchiveTodayOptions> {
 
   /**
    * Fetch archived snapshots from Archive.today.
+   *
+   * A memento's `datetime` is not always something `Date` can read, but the
+   * snapshot URL names the same instant, so its stamp is the fallback. Stamping
+   * "now" instead would push the row above every real capture once a merged
+   * response sorts newest-first; a row with no readable time at all is dropped.
    */
   async snapshots(domain: string, reqOptions: ArchiveTodayOptions = {}): Promise<ArchiveResponse> {
     const cleanDomain = normalizeDomain(domain, false);
@@ -62,10 +68,22 @@ export class ArchiveTodayProvider extends BaseProvider<ArchiveTodayOptions> {
 
         if (origUrl.includes(cleanDomain)) {
           try {
+            // The snapshot URL carries the capture stamp too, so a datetime the
+            // regex matched but `Date` cannot read falls back to those digits.
+            // Fabricating the current time instead would sort the capture above
+            // every real one in a merged, newest-first response, and the cache
+            // would then repeat that answer for days.
             const parsedDate = new Date(datetime);
             const isoTimestamp = Number.isNaN(parsedDate.getTime())
-              ? new Date().toISOString()
+              ? waybackTimestampToISO(timestamp)
               : parsedDate.toISOString();
+            if (!isoTimestamp) {
+              consola.debug("[archive-today] Dropping memento with unreadable capture time", {
+                datetime,
+                snapshot: snapshotUrl,
+              });
+              continue;
+            }
             const cleanedUrl = withoutTrailingSlash(
               cleanDoubleSlashes(origUrl.includes("://") ? origUrl : `https://${origUrl}`),
             );

--- a/test/archive-today.test.ts
+++ b/test/archive-today.test.ts
@@ -53,6 +53,28 @@ describe("archive.today", () => {
     );
   });
 
+  it("falls back to the snapshot URL stamp when a memento datetime is unreadable", async () => {
+    const mockTimemapResponse = `
+    <http://archive.md/20140101030405/https://example.com/>; rel="memento"; datetime="not a date",
+    <http://archive.md/201503081/https://example.com/>; rel="memento"; datetime="also not a date",
+    <http://archive.md/20160810200921/https://example.com/>; rel="memento"; datetime="Wed, 10 Aug 2016 20:09:21 GMT"
+    `;
+
+    vi.mocked($fetch).mockResolvedValueOnce(mockTimemapResponse);
+
+    const archive = createArchiveClient(createArchiveToday());
+    const result = await archive.snapshots("example.com");
+
+    expect(result.success).toBe(true);
+    // The first memento keeps the capture time its URL names instead of "now";
+    // the second has no readable time anywhere and is dropped.
+    expect(result.pages).toHaveLength(2);
+    expect(result.pages[0].timestamp).toBe("2014-01-01T03:04:05Z");
+    expect(result.pages[0]._meta.hash).toBe("20140101030405");
+    expect(result.pages[1].timestamp).toBe("2016-08-10T20:09:21.000Z");
+    expect(result.pages[1]._meta.position).toBe(1);
+  });
+
   it("returns an error response when the Memento API fails", async () => {
     vi.mocked($fetch).mockRejectedValueOnce(new Error("API error"));
 


### PR DESCRIPTION
An unreadable memento datetime got stamped with `new Date()`, so a single mangled timemap row claimed it was captured just now, outranked every real capture in the merged newest-first sort, and then stuck around in the 7-day cache. The snapshot URL already names the capture instant, so its digits are the fallback now; a row with no readable time at all is dropped, same way the Common Crawl provider treats its bad rows.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/agntn/archives/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

