### PR TITLE
fix: forward the cancellation signal to Conifer searches

### DIFF
--- a/src/providers/conifer.ts
+++ b/src/providers/conifer.ts
@@ -81,6 +81,7 @@ export class ConiferProvider extends BaseProvider<ConiferOptions> {
       }
       const fetchOptions = await createFetchOptions(baseUrl, params, {
         retries: options.retries,
+        signal: options.signal,
         timeout: options.timeout,
       });
       const response = await $fetch<ConiferSearchResponse>("/api/v1/url_search", {

--- a/test/conifer.test.ts
+++ b/test/conifer.test.ts
@@ -71,6 +71,21 @@ describe("Conifer", () => {
     );
   });
 
+  it("forwards the caller's cancellation signal to the search request", async () => {
+    vi.mocked($fetch).mockResolvedValueOnce({ results: [] });
+
+    const controller = new AbortController();
+    await createArchive(createConifer({ user: "user", collection: "collection" })).snapshots(
+      "example.com",
+      { signal: controller.signal },
+    );
+
+    expect($fetch).toHaveBeenCalledWith(
+      "/api/v1/url_search",
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+
   it.each([1, 1.5])("applies a requested limit of %s to Conifer results", async (limit) => {
     vi.mocked($fetch).mockResolvedValueOnce({
       results: [


### PR DESCRIPTION
The abort wiring from #30 stops one provider short: Conifer branched off before it landed and never passes `signal` to its fetch. The search just keeps running after the tool call is already cancelled.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/agntn/archives/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

