### PR TITLE
feat: filter snapshot listings by time window

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ const archive = createArchive(
 );
 ```
 
+### Time window
+
+`snapshots()` takes `from` and `to` bounds, as archive digits (`2019`, `201903`, up to `20190301120000`) or ISO 8601 dates. Both are inclusive, and a partial value covers the whole period it names, so `from: '2019', to: '2019'` is the entire year:
+
+```ts
+const response = await archive.snapshots("example.com", { from: "2019", to: "2019-06" });
+```
+
+Providers whose index takes a window (Wayback, Archive-It) narrow the query itself; for the rest the listing is filtered after it returns, so captures outside the window never mix into a fan-out. A filtered listing can come back shorter than `limit` - raise it when a sparse window needs more of the archive.
+
 ### Perma.cc
 
 Perma.cc requires an API key and searches archives accessible to that account by exact submitted URL:
@@ -193,7 +203,7 @@ An MCP client sees the text a tool returns and nothing else, so the text carries
 
 `archives_content` returns the capture's original URL, its date, the snapshot it was read from, and the body, with markup stripped to readable text unless `format=raw` and clipped to `maxChars` (20 000 by default) with a note saying so. The body is fenced and labelled as untrusted data: it is a recording of a web page, not a message to the caller. A capture that is not text is described instead of decoded.
 
-`archives_snapshots` is annotated read-only and open-world: it leaves the machine on every call, and archives keep growing, so two identical calls may legitimately differ. An answer replayed from the response cache is marked `; cached` in its header. A provider that returns no snapshots is an answer, not a tool error. Only a rejected argument or a failed query sets `isError`.
+`archives_snapshots` is annotated read-only and open-world: it leaves the machine on every call, and archives keep growing, so two identical calls may legitimately differ. An answer replayed from the response cache is marked `; cached` in its header. A provider that returns no snapshots is an answer, not a tool error. Only a rejected argument or a failed query sets `isError`. `from` and `to` bound the listing to a time window, and the applied window is echoed in the header so a narrowed answer never reads as the archive's whole holdings.
 
 The Perma.cc key is read from `PERMA_CC_API_KEY` or `PERMACC_API_KEY` and never accepted as a tool argument; it is redacted before the options reach any result.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const archive = createArchive(
 const response = await archive.snapshots("example.com", { from: "2019", to: "2019-06" });
 ```
 
-Providers whose index takes a window (Wayback, Archive-It) narrow the query itself; for the rest the listing is filtered after it returns, so captures outside the window never mix into a fan-out. While a window is active, `limit` applies after the filter rather than at the provider, so a tight limit cannot eat the window.
+Providers whose index takes a window (Wayback, Archive-It) narrow the query itself; for the rest the listing is filtered after it returns, so captures outside the window never mix into a fan-out. While a window is active, `limit` applies after the filter rather than at the provider, so a tight limit cannot eat the window. What the window cannot reach past is a provider's own batch ceiling: Common Crawl and Conifer serve at most 1000 index rows per query and Perma.cc 100, and the library does not paginate beyond them.
 
 ### Perma.cc
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const archive = createArchive(
 const response = await archive.snapshots("example.com", { from: "2019", to: "2019-06" });
 ```
 
-Providers whose index takes a window (Wayback, Archive-It) narrow the query itself; for the rest the listing is filtered after it returns, so captures outside the window never mix into a fan-out. A filtered listing can come back shorter than `limit` - raise it when a sparse window needs more of the archive.
+Providers whose index takes a window (Wayback, Archive-It) narrow the query itself; for the rest the listing is filtered after it returns, so captures outside the window never mix into a fan-out. While a window is active, `limit` applies after the filter rather than at the provider, so a tight limit cannot eat the window.
 
 ### Perma.cc
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const archive = createArchive(
 const response = await archive.snapshots("example.com", { from: "2019", to: "2019-06" });
 ```
 
-Providers whose index takes a window (Wayback, Archive-It) narrow the query itself; for the rest the listing is filtered after it returns, so captures outside the window never mix into a fan-out. While a window is active, `limit` applies after the filter rather than at the provider, so a tight limit cannot eat the window. What the window cannot reach past is a provider's own batch ceiling: Common Crawl and Conifer serve at most 1000 index rows per query and Perma.cc 100, and the library does not paginate beyond them.
+Providers whose index takes a window (Wayback, Archive-It) narrow the query itself; for the rest the listing is filtered after it returns, so captures outside the window never mix into a fan-out. While a window is active, `limit` applies after the filter rather than at the provider, so a tight limit cannot eat the window. What the window cannot reach past is the single batch a windowed fetch asks for: up to 1000 index rows from Common Crawl and Conifer, 100 from Perma.cc, and the library does not paginate beyond that.
 
 ### Perma.cc
 

--- a/packages/omp/extensions/archives.ts
+++ b/packages/omp/extensions/archives.ts
@@ -377,6 +377,8 @@ function renderSnapshotCall(params: SnapshotParams, theme: RenderTheme): string 
   parts.push(theme.fg("dim", truncateSingleLine(sanitizeTerminalText(params.target), 120)));
   if (params.provider) parts.push(theme.fg("muted", `provider=${sanitizeLine(params.provider)}`));
   if (params.limit !== undefined) parts.push(theme.fg("muted", `limit=${params.limit}`));
+  if (params.from) parts.push(theme.fg("muted", `from=${sanitizeLine(params.from)}`));
+  if (params.to) parts.push(theme.fg("muted", `to=${sanitizeLine(params.to)}`));
   if (params.collection)
     parts.push(theme.fg("muted", `collection=${sanitizeLine(params.collection)}`));
   if (params.timeout !== undefined) parts.push(theme.fg("muted", `timeout=${params.timeout}`));

--- a/packages/omp/extensions/archives.ts
+++ b/packages/omp/extensions/archives.ts
@@ -54,6 +54,8 @@ const PROVIDER_HINT = `Provider to use. "auto" (or omit) uses "all", which queri
 const CONTENT_PROVIDER_HINT = `Provider to read from. "auto" (or omit) uses "all", which tries Wayback first and falls back to Common Crawl. Archive-It reads bodies too, with a numeric collection id. Archive.today, Conifer, WebCite and Perma.cc serve no readable capture bodies and answer as unsupported.`;
 const CONTENT_FORMATS = ["text", "raw"] as const;
 const CONTENT_FORMAT_HINT = `How to return the body. "text" (default) strips markup from an HTML capture and returns what a reader would see; "raw" returns the archived bytes as they were served.`;
+const SNAPSHOT_FROM_HINT = `Earliest capture to list, as archive digits (YYYY through YYYYMMDDhhmmss) or an ISO 8601 date. Inclusive; a partial stamp starts the window at the beginning of the period it names.`;
+const SNAPSHOT_TO_HINT = `Latest capture to list, in the same formats as "from". Inclusive; a partial stamp stretches the window to the end of the period it names, so from=2019 with to=2019 covers the whole year.`;
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 100;
 const DEFAULT_MAX_CHARS = 20_000;
@@ -160,6 +162,20 @@ const snapshotParameters = Type.Object({
       description: "Wayback CDX filter parameter.",
       minLength: 1,
       maxLength: MAX_PARAMETER_LENGTH,
+    }),
+  ),
+  from: Type.Optional(
+    Type.String({
+      description: SNAPSHOT_FROM_HINT,
+      minLength: 1,
+      maxLength: MAX_TIMESTAMP_LENGTH,
+    }),
+  ),
+  to: Type.Optional(
+    Type.String({
+      description: SNAPSHOT_TO_HINT,
+      minLength: 1,
+      maxLength: MAX_TIMESTAMP_LENGTH,
     }),
   ),
 });

--- a/packages/pi/extensions/archives.ts
+++ b/packages/pi/extensions/archives.ts
@@ -54,6 +54,8 @@ const PROVIDER_HINT = `Provider to use. "auto" (or omit) uses "all", which queri
 const CONTENT_PROVIDER_HINT = `Provider to read from. "auto" (or omit) uses "all", which tries Wayback first and falls back to Common Crawl. Archive-It reads bodies too, with a numeric collection id. Archive.today, Conifer, WebCite and Perma.cc serve no readable capture bodies and answer as unsupported.`;
 const CONTENT_FORMATS = ["text", "raw"] as const;
 const CONTENT_FORMAT_HINT = `How to return the body. "text" (default) strips markup from an HTML capture and returns what a reader would see; "raw" returns the archived bytes as they were served.`;
+const SNAPSHOT_FROM_HINT = `Earliest capture to list, as archive digits (YYYY through YYYYMMDDhhmmss) or an ISO 8601 date. Inclusive; a partial stamp starts the window at the beginning of the period it names.`;
+const SNAPSHOT_TO_HINT = `Latest capture to list, in the same formats as "from". Inclusive; a partial stamp stretches the window to the end of the period it names, so from=2019 with to=2019 covers the whole year.`;
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 100;
 const DEFAULT_MAX_CHARS = 20_000;
@@ -162,6 +164,20 @@ const snapshotParameters = Type.Object({
       description: "Wayback CDX filter parameter.",
       minLength: 1,
       maxLength: MAX_PARAMETER_LENGTH,
+    }),
+  ),
+  from: Type.Optional(
+    Type.String({
+      description: SNAPSHOT_FROM_HINT,
+      minLength: 1,
+      maxLength: MAX_TIMESTAMP_LENGTH,
+    }),
+  ),
+  to: Type.Optional(
+    Type.String({
+      description: SNAPSHOT_TO_HINT,
+      minLength: 1,
+      maxLength: MAX_TIMESTAMP_LENGTH,
     }),
   ),
 });

--- a/packages/pi/extensions/archives.ts
+++ b/packages/pi/extensions/archives.ts
@@ -397,6 +397,8 @@ function renderSnapshotCall(params: SnapshotParams, theme: RenderTheme): string 
   parts.push(theme.fg("dim", truncateSingleLine(sanitizeTerminalText(params.target), 120)));
   if (params.provider) parts.push(theme.fg("muted", `provider=${sanitizeLine(params.provider)}`));
   if (params.limit !== undefined) parts.push(theme.fg("muted", `limit=${params.limit}`));
+  if (params.from) parts.push(theme.fg("muted", `from=${sanitizeLine(params.from)}`));
+  if (params.to) parts.push(theme.fg("muted", `to=${sanitizeLine(params.to)}`));
   if (params.collection)
     parts.push(theme.fg("muted", `collection=${sanitizeLine(params.collection)}`));
   if (params.timeout !== undefined) parts.push(theme.fg("muted", `timeout=${params.timeout}`));

--- a/src/_providers.ts
+++ b/src/_providers.ts
@@ -9,8 +9,6 @@ export interface ArchiveItOptions extends ArchiveOptions {
   collection: number | string;
   collapse?: string;
   filter?: string;
-  from?: string;
-  to?: string;
 }
 
 export interface ConiferOptions extends ArchiveOptions {

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -14,7 +14,10 @@ import { getStoredContent, getStoredResponse, storeContent, storeResponse } from
 import {
   mergeOptions,
   processInParallel,
+  timestampLowerBound,
+  timestampUpperBound,
   toErrorMessage,
+  toWaybackTimestamp,
   unreadableTargetReason,
   unwrapSnapshotUrl,
 } from "./utils";
@@ -214,6 +217,49 @@ export function combineContentResults(responses: ArchiveContentResponse[]): Arch
 }
 
 /**
+ * Validates one edge of a listing window and reduces it to timestamp digits.
+ *
+ * @param name - Which option the value came from, for the error message
+ * @param value - Wayback-style digits or an ISO 8601 date
+ * @returns Validated digits, empty when the edge is open
+ * @throws When the value is not a timestamp any archive could act on
+ */
+function resolveWindowBound(name: "from" | "to", value: string | undefined): string {
+  if (value === undefined || value.trim() === "") return "";
+
+  const digits = toWaybackTimestamp(value);
+  if (!digits) {
+    throw new Error(
+      `Invalid ${name} "${value}": use archive digits (YYYY to YYYYMMDDhhmmss) or an ISO 8601 date`,
+    );
+  }
+
+  return digits;
+}
+
+/**
+ * Drops the pages outside the requested window.
+ *
+ * Providers that can narrow their own index query already have; this is the
+ * guarantee for the ones that cannot, so a fan-out never mixes in-window
+ * listings with out-of-window ones.
+ */
+function windowPages(response: ArchiveResponse, from: string, to: string): ArchiveResponse {
+  if ((!from && !to) || !response.success || response.pages.length === 0) return response;
+
+  const lower = from ? timestampLowerBound(from) : "";
+  const upper = to ? timestampUpperBound(to) : "";
+  const pages = response.pages.filter((page) => {
+    // A capture whose date cannot be read cannot be placed inside the window.
+    const stamp = toWaybackTimestamp(page.timestamp);
+    if (!stamp) return false;
+    return (!lower || stamp >= lower) && (!upper || stamp <= upper);
+  });
+
+  return pages.length === response.pages.length ? response : { ...response, pages };
+}
+
+/**
  * Unified archive client aggregating one or more `ArchiveProvider`s.
  *
  * Use `createArchive()` for the functional entry point; the class exists so
@@ -312,21 +358,48 @@ export class Archive implements ArchiveInterface {
    *   limit: 5,
    *   cache: false // Skip cache for this request
    * })
+   *
+   * // Only the captures from the first half of 2019
+   * const response = await archive.snapshots('example.com', {
+   *   from: '2019',
+   *   to: '2019-06'
+   * })
    * ```
    */
   async snapshots(domain: string, listOptions?: ArchiveOptions): Promise<ArchiveResponse> {
-    const mergedOptions = await mergeOptions(this.options, listOptions);
+    const {
+      from: rawFrom,
+      to: rawTo,
+      ...restOptions
+    } = await mergeOptions(this.options, listOptions);
+
+    const from = resolveWindowBound("from", rawFrom);
+    const to = resolveWindowBound("to", rawTo);
+    if (from && to && timestampLowerBound(from) > timestampUpperBound(to)) {
+      throw new Error(`Window is inverted: from "${from}" is later than to "${to}"`);
+    }
+
+    // Providers see validated digits only, so what reaches an index query and a
+    // cache key never depends on how the caller spelled the instant.
+    const mergedOptions: ArchiveOptions = {
+      ...restOptions,
+      ...(from ? { from } : {}),
+      ...(to ? { to } : {}),
+    };
+
     const providerArray = await this.resolveProviders();
 
     // For a single provider, use direct approach
     if (providerArray.length === 1) {
-      return this.fetchFromProvider(providerArray[0], domain, mergedOptions);
+      const response = await this.fetchFromProvider(providerArray[0], domain, mergedOptions);
+      return windowPages(response, from, to);
     }
 
     // For multiple providers, fetch in parallel with concurrency control
     const responses = await processInParallel(
       providerArray,
-      (provider) => this.fetchFromProvider(provider, domain, mergedOptions),
+      async (provider) =>
+        windowPages(await this.fetchFromProvider(provider, domain, mergedOptions), from, to),
       {
         concurrency: mergedOptions.concurrency,
         batchSize: mergedOptions.batchSize,

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -242,7 +242,8 @@ function resolveWindowBound(name: "from" | "to", value: string | undefined): str
  *
  * Providers that can narrow their own index query already have; this is the
  * guarantee for the ones that cannot, so a fan-out never mixes in-window
- * listings with out-of-window ones.
+ * listings with out-of-window ones. A capture whose date cannot be read cannot
+ * be placed inside the window, so it drops with them.
  */
 function windowPages(response: ArchiveResponse, from: string, to: string): ArchiveResponse {
   if ((!from && !to) || !response.success || response.pages.length === 0) return response;
@@ -250,7 +251,6 @@ function windowPages(response: ArchiveResponse, from: string, to: string): Archi
   const lower = from ? timestampLowerBound(from) : "";
   const upper = to ? timestampUpperBound(to) : "";
   const pages = response.pages.filter((page) => {
-    // A capture whose date cannot be read cannot be placed inside the window.
     const stamp = toWaybackTimestamp(page.timestamp);
     if (!stamp) return false;
     return (!lower || stamp >= lower) && (!upper || stamp <= upper);
@@ -351,6 +351,15 @@ export class Archive implements ArchiveInterface {
    * Fetch archived snapshots for a domain.
    * Returns a full response object with pages, metadata, and cache status.
    *
+   * A `from`/`to` window is validated once here, normalized to digits, and
+   * completed per provider, because init-level bounds count too and a provider
+   * without a window-aware index cannot apply them itself. A windowed fetch
+   * runs with the provider limits lifted; every cap returns after the filter,
+   * the caller's after the newest-first merge, since a cap taken earlier turns
+   * a tight limit into a false "nothing captured in this window". An inverted
+   * window throws before the fan-out, where the parallel runner would swallow
+   * the error.
+   *
    * @param domain - The domain to search for in archive services (e.g., "example.com")
    * @param listOptions - Request-specific options that override the default options
    * @returns Promise resolving to ArchiveResponse with pages, metadata and status
@@ -386,8 +395,6 @@ export class Archive implements ArchiveInterface {
       throw new Error(`Window is inverted: from "${from}" is later than to "${to}"`);
     }
 
-    // Providers see validated digits only, so what reaches an index query and a
-    // cache key never depends on how the caller spelled the instant.
     const mergedOptions: ArchiveOptions = {
       ...restOptions,
       ...(from ? { from } : {}),
@@ -396,14 +403,7 @@ export class Archive implements ArchiveInterface {
 
     const providerArray = await this.resolveProviders();
 
-    // The effective window completes the option cascade per provider: a bound
-    // set at initialization counts too, because a provider without a
-    // window-aware index cannot apply its own. Request and archive bounds win
-    // per edge, and an init bound faces the same validation as they did: a
-    // value no archive could act on throws instead of silently widening the
-    // window. Inversion is checked here, after the cascade, and before the
-    // fan-out so the error surfaces instead of being swallowed by the parallel
-    // runner.
+    /** Effective per-provider window: request and archive bounds win per edge, init bounds complete the cascade, and an inverted result throws ahead of the fan-out. */
     const windowed = providerArray.map((provider) => {
       const windowFrom = from || resolveWindowBound("from", provider.options?.from);
       const windowTo = to || resolveWindowBound("to", provider.options?.to);
@@ -417,6 +417,14 @@ export class Archive implements ArchiveInterface {
       return { provider, windowFrom, windowTo };
     });
 
+    /**
+     * One provider's windowed listing. The fetch runs with every limit lifted,
+     * as an explicit undefined so the provider's own cascade cannot restore an
+     * init-level value, and with the validated digits in the request options,
+     * so a pushdown index never sees a raw init-level date and the cache key
+     * separates this fetch from a naturally capped one. The provider's own cap
+     * comes back after the filter.
+     */
     const fetchWindowed = async ({
       provider,
       windowFrom,
@@ -426,13 +434,6 @@ export class Archive implements ArchiveInterface {
         return this.fetchFromProvider(provider, domain, mergedOptions);
       }
 
-      // A provider-side limit caps the rows before the window applies, so a
-      // tight limit turns into a false "nothing captured in this window". The
-      // explicit undefined is what lifts an init-level limit too: an absent key
-      // would let the provider's own option cascade restore it. The effective
-      // bounds travel in the request options, so a pushdown index receives
-      // validated digits even when the bound came in as an init-level ISO date,
-      // and the cache key separates this fetch from a naturally capped one.
       const bounded: ArchiveOptions = {
         ...mergedOptions,
         limit: undefined,
@@ -440,8 +441,6 @@ export class Archive implements ArchiveInterface {
         ...(windowTo ? { to: windowTo } : {}),
       };
       const response = await this.fetchFromProvider(provider, domain, bounded);
-      // An init-level limit is the provider's own cap, so it comes back after
-      // the filter, the same way the caller's limit does.
       return capPages(windowPages(response, windowFrom, windowTo), provider.options?.limit);
     };
 
@@ -449,17 +448,12 @@ export class Archive implements ArchiveInterface {
     if (providerArray.length === 1) {
       const [single] = windowed;
       const response = await fetchWindowed(single);
-      // With the provider limit lifted, the cap the caller asked for is applied
-      // here, after the filter.
       return single.windowFrom || single.windowTo
         ? capPages(response, mergedOptions.limit)
         : response;
     }
 
-    // For multiple providers, fetch in parallel with concurrency control.
-    // Responses stay uncapped through the fan-out: combineResults sorts the
-    // merged pages newest first before limiting, and a per-provider cap taken
-    // in the provider's own order would discard the rows that sort keeps.
+    // For multiple providers, fetch in parallel with concurrency control
     const responses = await processInParallel(windowed, fetchWindowed, {
       concurrency: mergedOptions.concurrency,
       batchSize: mergedOptions.batchSize,

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -14,6 +14,7 @@ import { getStoredContent, getStoredResponse, storeContent, storeResponse } from
 import {
   mergeOptions,
   processInParallel,
+  resolveRequestedTimestamp,
   timestampLowerBound,
   timestampUpperBound,
   toErrorMessage,
@@ -101,10 +102,7 @@ export function combineResults(responses: ArchiveResponse[], limit?: number): Ar
   // newest first
   allPages.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
 
-  const limitedPages =
-    typeof limit === "number" && Number.isFinite(limit)
-      ? allPages.slice(0, Math.max(0, limit))
-      : allPages;
+  const limitedPages = limitPages(allPages, limit);
 
   const providersList = responses.map((r) => r._meta?.provider || "unknown").filter(Boolean);
 
@@ -217,27 +215,6 @@ export function combineContentResults(responses: ArchiveContentResponse[]): Arch
 }
 
 /**
- * Validates one edge of a listing window and reduces it to timestamp digits.
- *
- * @param name - Which option the value came from, for the error message
- * @param value - Wayback-style digits or an ISO 8601 date
- * @returns Validated digits, empty when the edge is open
- * @throws When the value is not a timestamp any archive could act on
- */
-function resolveWindowBound(name: "from" | "to", value: string | undefined): string {
-  if (value === undefined || value.trim() === "") return "";
-
-  const digits = toWaybackTimestamp(value);
-  if (!digits) {
-    throw new Error(
-      `Invalid ${name} "${value}": use archive digits (YYYY to YYYYMMDDhhmmss) or an ISO 8601 date`,
-    );
-  }
-
-  return digits;
-}
-
-/**
  * Drops the pages outside the requested window.
  *
  * Providers that can narrow their own index query already have; this is the
@@ -246,7 +223,7 @@ function resolveWindowBound(name: "from" | "to", value: string | undefined): str
  * be placed inside the window, so it drops with them.
  */
 function windowPages(response: ArchiveResponse, from: string, to: string): ArchiveResponse {
-  if ((!from && !to) || !response.success || response.pages.length === 0) return response;
+  if (!response.success) return response;
 
   const lower = from ? timestampLowerBound(from) : "";
   const upper = to ? timestampUpperBound(to) : "";
@@ -259,11 +236,16 @@ function windowPages(response: ArchiveResponse, from: string, to: string): Archi
   return pages.length === response.pages.length ? response : { ...response, pages };
 }
 
+/** One shared clamp, so the merge and the windowed paths cannot drift on limit semantics. */
+function limitPages(pages: ArchivedPage[], limit: number | undefined): ArchivedPage[] {
+  if (typeof limit !== "number" || !Number.isFinite(limit)) return pages;
+  return pages.length <= limit ? pages : pages.slice(0, Math.max(0, limit));
+}
+
 /** Caps the pages of one filtered response, the way the lifted provider limit would have. */
 function capPages(response: ArchiveResponse, limit: number | undefined): ArchiveResponse {
-  if (typeof limit !== "number" || !Number.isFinite(limit)) return response;
-  if (response.pages.length <= limit) return response;
-  return { ...response, pages: response.pages.slice(0, Math.max(0, limit)) };
+  const pages = limitPages(response.pages, limit);
+  return pages === response.pages ? response : { ...response, pages };
 }
 
 /**
@@ -389,24 +371,15 @@ export class Archive implements ArchiveInterface {
       ...restOptions
     } = await mergeOptions(this.options, listOptions);
 
-    const from = resolveWindowBound("from", rawFrom);
-    const to = resolveWindowBound("to", rawTo);
-    if (from && to && timestampLowerBound(from) > timestampUpperBound(to)) {
-      throw new Error(`Window is inverted: from "${from}" is later than to "${to}"`);
-    }
-
-    const mergedOptions: ArchiveOptions = {
-      ...restOptions,
-      ...(from ? { from } : {}),
-      ...(to ? { to } : {}),
-    };
+    const from = resolveRequestedTimestamp(rawFrom, "from");
+    const to = resolveRequestedTimestamp(rawTo, "to");
 
     const providerArray = await this.resolveProviders();
 
     /** Effective per-provider window: request and archive bounds win per edge, init bounds complete the cascade, and an inverted result throws ahead of the fan-out. */
     const windowed = providerArray.map((provider) => {
-      const windowFrom = from || resolveWindowBound("from", provider.options?.from);
-      const windowTo = to || resolveWindowBound("to", provider.options?.to);
+      const windowFrom = from || resolveRequestedTimestamp(provider.options?.from, "from");
+      const windowTo = to || resolveRequestedTimestamp(provider.options?.to, "to");
       if (
         windowFrom &&
         windowTo &&
@@ -431,11 +404,11 @@ export class Archive implements ArchiveInterface {
       windowTo,
     }: (typeof windowed)[number]): Promise<ArchiveResponse> => {
       if (!windowFrom && !windowTo) {
-        return this.fetchFromProvider(provider, domain, mergedOptions);
+        return this.fetchFromProvider(provider, domain, restOptions);
       }
 
       const bounded: ArchiveOptions = {
-        ...mergedOptions,
+        ...restOptions,
         limit: undefined,
         ...(windowFrom ? { from: windowFrom } : {}),
         ...(windowTo ? { to: windowTo } : {}),
@@ -449,17 +422,17 @@ export class Archive implements ArchiveInterface {
       const [single] = windowed;
       const response = await fetchWindowed(single);
       return single.windowFrom || single.windowTo
-        ? capPages(response, mergedOptions.limit)
+        ? capPages(response, restOptions.limit)
         : response;
     }
 
     // For multiple providers, fetch in parallel with concurrency control
     const responses = await processInParallel(windowed, fetchWindowed, {
-      concurrency: mergedOptions.concurrency,
-      batchSize: mergedOptions.batchSize,
+      concurrency: restOptions.concurrency,
+      batchSize: restOptions.batchSize,
     });
 
-    return combineResults(responses, mergedOptions.limit);
+    return combineResults(responses, restOptions.limit);
   }
 
   /**

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -396,7 +396,10 @@ export class Archive implements ArchiveInterface {
      * init-level value, and with the validated digits in the request options,
      * so a pushdown index never sees a raw init-level date and the cache key
      * separates this fetch from a naturally capped one. The provider's own cap
-     * comes back after the filter.
+     * comes back after the filter, but only while the request names no limit of
+     * its own: a request limit outranks the init level, and in a fan-out it is
+     * applied after the newest-first merge rather than here, where it would cut
+     * in the provider's order.
      */
     const fetchWindowed = async ({
       provider,
@@ -414,7 +417,10 @@ export class Archive implements ArchiveInterface {
         ...(windowTo ? { to: windowTo } : {}),
       };
       const response = await this.fetchFromProvider(provider, domain, bounded);
-      return capPages(windowPages(response, windowFrom, windowTo), provider.options?.limit);
+      return capPages(
+        windowPages(response, windowFrom, windowTo),
+        restOptions.limit === undefined ? provider.options?.limit : undefined,
+      );
     };
 
     // For a single provider, use direct approach

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -399,13 +399,14 @@ export class Archive implements ArchiveInterface {
     // The effective window completes the option cascade per provider: a bound
     // set at initialization counts too, because a provider without a
     // window-aware index cannot apply its own. Request and archive bounds win
-    // per edge; an init bound that parses as no timestamp stays the provider's
-    // problem, as it always was. Inversion is checked here, after the cascade,
-    // and before the fan-out so the error surfaces instead of being swallowed
-    // by the parallel runner.
+    // per edge, and an init bound faces the same validation as they did: a
+    // value no archive could act on throws instead of silently widening the
+    // window. Inversion is checked here, after the cascade, and before the
+    // fan-out so the error surfaces instead of being swallowed by the parallel
+    // runner.
     const windowed = providerArray.map((provider) => {
-      const windowFrom = from || toWaybackTimestamp(provider.options?.from ?? "");
-      const windowTo = to || toWaybackTimestamp(provider.options?.to ?? "");
+      const windowFrom = from || resolveWindowBound("from", provider.options?.from);
+      const windowTo = to || resolveWindowBound("to", provider.options?.to);
       if (
         windowFrom &&
         windowTo &&
@@ -428,10 +429,20 @@ export class Archive implements ArchiveInterface {
       // A provider-side limit caps the rows before the window applies, so a
       // tight limit turns into a false "nothing captured in this window". The
       // explicit undefined is what lifts an init-level limit too: an absent key
-      // would let the provider's own option cascade restore it.
-      const unlimited: ArchiveOptions = { ...mergedOptions, limit: undefined };
-      const response = await this.fetchFromProvider(provider, domain, unlimited);
-      return windowPages(response, windowFrom, windowTo);
+      // would let the provider's own option cascade restore it. The effective
+      // bounds travel in the request options, so a pushdown index receives
+      // validated digits even when the bound came in as an init-level ISO date,
+      // and the cache key separates this fetch from a naturally capped one.
+      const bounded: ArchiveOptions = {
+        ...mergedOptions,
+        limit: undefined,
+        ...(windowFrom ? { from: windowFrom } : {}),
+        ...(windowTo ? { to: windowTo } : {}),
+      };
+      const response = await this.fetchFromProvider(provider, domain, bounded);
+      // An init-level limit is the provider's own cap, so it comes back after
+      // the filter, the same way the caller's limit does.
+      return capPages(windowPages(response, windowFrom, windowTo), provider.options?.limit);
     };
 
     // For a single provider, use direct approach

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -259,6 +259,13 @@ function windowPages(response: ArchiveResponse, from: string, to: string): Archi
   return pages.length === response.pages.length ? response : { ...response, pages };
 }
 
+/** Caps the pages of one filtered response, the way the lifted provider limit would have. */
+function capPages(response: ArchiveResponse, limit: number | undefined): ArchiveResponse {
+  if (typeof limit !== "number" || !Number.isFinite(limit)) return response;
+  if (response.pages.length <= limit) return response;
+  return { ...response, pages: response.pages.slice(0, Math.max(0, limit)) };
+}
+
 /**
  * Unified archive client aggregating one or more `ArchiveProvider`s.
  *
@@ -389,22 +396,36 @@ export class Archive implements ArchiveInterface {
 
     const providerArray = await this.resolveProviders();
 
+    // The effective window completes the option cascade per provider: a bound
+    // set at initialization counts too, because a provider without a
+    // window-aware index cannot apply its own. Request and archive bounds win
+    // per edge; an init bound that parses as no timestamp stays the provider's
+    // problem, as it always was.
+    const fetchWindowed = async (provider: ArchiveProvider): Promise<ArchiveResponse> => {
+      const windowFrom = from || toWaybackTimestamp(provider.options?.from ?? "");
+      const windowTo = to || toWaybackTimestamp(provider.options?.to ?? "");
+      if (!windowFrom && !windowTo) {
+        return this.fetchFromProvider(provider, domain, mergedOptions);
+      }
+
+      // A provider-side limit caps the rows before the window applies, so a
+      // tight limit turns into a false "nothing captured in this window". The
+      // cap moves after the filter instead, at the price of a fuller fetch.
+      const { limit: _limit, ...unlimited } = mergedOptions;
+      const response = await this.fetchFromProvider(provider, domain, unlimited);
+      return capPages(windowPages(response, windowFrom, windowTo), mergedOptions.limit);
+    };
+
     // For a single provider, use direct approach
     if (providerArray.length === 1) {
-      const response = await this.fetchFromProvider(providerArray[0], domain, mergedOptions);
-      return windowPages(response, from, to);
+      return fetchWindowed(providerArray[0]);
     }
 
     // For multiple providers, fetch in parallel with concurrency control
-    const responses = await processInParallel(
-      providerArray,
-      async (provider) =>
-        windowPages(await this.fetchFromProvider(provider, domain, mergedOptions), from, to),
-      {
-        concurrency: mergedOptions.concurrency,
-        batchSize: mergedOptions.batchSize,
-      },
-    );
+    const responses = await processInParallel(providerArray, fetchWindowed, {
+      concurrency: mergedOptions.concurrency,
+      batchSize: mergedOptions.batchSize,
+    });
 
     return combineResults(responses, mergedOptions.limit);
   }

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -400,29 +400,56 @@ export class Archive implements ArchiveInterface {
     // set at initialization counts too, because a provider without a
     // window-aware index cannot apply its own. Request and archive bounds win
     // per edge; an init bound that parses as no timestamp stays the provider's
-    // problem, as it always was.
-    const fetchWindowed = async (provider: ArchiveProvider): Promise<ArchiveResponse> => {
+    // problem, as it always was. Inversion is checked here, after the cascade,
+    // and before the fan-out so the error surfaces instead of being swallowed
+    // by the parallel runner.
+    const windowed = providerArray.map((provider) => {
       const windowFrom = from || toWaybackTimestamp(provider.options?.from ?? "");
       const windowTo = to || toWaybackTimestamp(provider.options?.to ?? "");
+      if (
+        windowFrom &&
+        windowTo &&
+        timestampLowerBound(windowFrom) > timestampUpperBound(windowTo)
+      ) {
+        throw new Error(`Window is inverted: from "${windowFrom}" is later than to "${windowTo}"`);
+      }
+      return { provider, windowFrom, windowTo };
+    });
+
+    const fetchWindowed = async ({
+      provider,
+      windowFrom,
+      windowTo,
+    }: (typeof windowed)[number]): Promise<ArchiveResponse> => {
       if (!windowFrom && !windowTo) {
         return this.fetchFromProvider(provider, domain, mergedOptions);
       }
 
       // A provider-side limit caps the rows before the window applies, so a
       // tight limit turns into a false "nothing captured in this window". The
-      // cap moves after the filter instead, at the price of a fuller fetch.
-      const { limit: _limit, ...unlimited } = mergedOptions;
+      // explicit undefined is what lifts an init-level limit too: an absent key
+      // would let the provider's own option cascade restore it.
+      const unlimited: ArchiveOptions = { ...mergedOptions, limit: undefined };
       const response = await this.fetchFromProvider(provider, domain, unlimited);
-      return capPages(windowPages(response, windowFrom, windowTo), mergedOptions.limit);
+      return windowPages(response, windowFrom, windowTo);
     };
 
     // For a single provider, use direct approach
     if (providerArray.length === 1) {
-      return fetchWindowed(providerArray[0]);
+      const [single] = windowed;
+      const response = await fetchWindowed(single);
+      // With the provider limit lifted, the cap the caller asked for is applied
+      // here, after the filter.
+      return single.windowFrom || single.windowTo
+        ? capPages(response, mergedOptions.limit)
+        : response;
     }
 
-    // For multiple providers, fetch in parallel with concurrency control
-    const responses = await processInParallel(providerArray, fetchWindowed, {
+    // For multiple providers, fetch in parallel with concurrency control.
+    // Responses stay uncapped through the fan-out: combineResults sorts the
+    // merged pages newest first before limiting, and a per-provider cap taken
+    // in the provider's own order would discard the rows that sort keeps.
+    const responses = await processInParallel(windowed, fetchWindowed, {
       concurrency: mergedOptions.concurrency,
       batchSize: mergedOptions.batchSize,
     });

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -27,6 +27,8 @@ import {
   PROVIDER_HINT,
   PROVIDER_INPUTS,
   sanitizeTerminalText,
+  SNAPSHOT_FROM_HINT,
+  SNAPSHOT_TO_HINT,
   snapshotArchives,
   type ContentParams,
   type SnapshotParams,
@@ -135,6 +137,20 @@ const tools: ToolDefinition[] = [
             description: "Wayback CDX filter parameter.",
             minLength: 1,
             maxLength: MAX_PARAMETER_LENGTH,
+          }),
+        ),
+        from: Type.Optional(
+          Type.String({
+            description: SNAPSHOT_FROM_HINT,
+            minLength: 1,
+            maxLength: MAX_TIMESTAMP_LENGTH,
+          }),
+        ),
+        to: Type.Optional(
+          Type.String({
+            description: SNAPSHOT_TO_HINT,
+            minLength: 1,
+            maxLength: MAX_TIMESTAMP_LENGTH,
           }),
         ),
       },

--- a/src/providers/archive-it.ts
+++ b/src/providers/archive-it.ts
@@ -54,15 +54,11 @@ export class ArchiveItProvider extends BaseProvider<ArchiveItOptions> {
     const collection = String(requestOptions?.collection ?? this.options.collection).trim();
     const collapse = requestOptions?.collapse ?? this.options.collapse;
     const filter = requestOptions?.filter ?? this.options.filter;
-    const from = requestOptions?.from ?? this.options.from;
-    const to = requestOptions?.to ?? this.options.to;
     const limit = requestOptions?.limit === undefined ? this.options.limit : undefined;
     const parts = [`collection=${encodeURIComponent(collection)}`];
 
     if (collapse !== undefined) parts.push(`collapse=${encodeURIComponent(collapse)}`);
     if (filter !== undefined) parts.push(`filter=${encodeURIComponent(filter)}`);
-    if (from !== undefined) parts.push(`from=${encodeURIComponent(from)}`);
-    if (to !== undefined) parts.push(`to=${encodeURIComponent(to)}`);
     if (limit !== undefined) parts.push(`limit=${limit}`);
 
     return parts.join(":");

--- a/src/providers/archive-it.ts
+++ b/src/providers/archive-it.ts
@@ -66,6 +66,10 @@ export class ArchiveItProvider extends BaseProvider<ArchiveItOptions> {
 
   /**
    * Fetch archived snapshots from one Archive-It collection.
+   *
+   * The window bounds are normalized here too, not only in `Archive.snapshots`:
+   * the provider is a public export, and the CDX index does not read a raw ISO
+   * date as an instant.
    */
   async snapshots(
     domain: string,
@@ -84,8 +88,10 @@ export class ArchiveItProvider extends BaseProvider<ArchiveItOptions> {
 
       if (options.collapse !== undefined) params.collapse = options.collapse;
       if (options.filter !== undefined) params.filter = options.filter;
-      if (options.from !== undefined) params.from = options.from;
-      if (options.to !== undefined) params.to = options.to;
+      const from = resolveRequestedTimestamp(options.from, "from");
+      const to = resolveRequestedTimestamp(options.to, "to");
+      if (from) params.from = from;
+      if (to) params.to = to;
 
       const fetchOptions = await createFetchOptions(baseUrl, params, {
         retries: options.retries,

--- a/src/providers/wayback.ts
+++ b/src/providers/wayback.ts
@@ -46,13 +46,9 @@ export class WaybackProvider extends BaseProvider<WaybackOptions> {
     const waybackOptions = options as Partial<WaybackOptions> | undefined;
     const collapse = waybackOptions?.collapse ?? this.options.collapse ?? "timestamp:4";
     const filter = waybackOptions?.filter ?? this.options.filter;
-    const from = waybackOptions?.from ?? this.options.from;
-    const to = waybackOptions?.to ?? this.options.to;
     const parts = [`collapse=${encodeURIComponent(collapse)}`];
 
     if (filter !== undefined) parts.push(`filter=${encodeURIComponent(filter)}`);
-    if (from !== undefined) parts.push(`from=${encodeURIComponent(from)}`);
-    if (to !== undefined) parts.push(`to=${encodeURIComponent(to)}`);
 
     return parts.join(":");
   }

--- a/src/providers/wayback.ts
+++ b/src/providers/wayback.ts
@@ -46,9 +46,13 @@ export class WaybackProvider extends BaseProvider<WaybackOptions> {
     const waybackOptions = options as Partial<WaybackOptions> | undefined;
     const collapse = waybackOptions?.collapse ?? this.options.collapse ?? "timestamp:4";
     const filter = waybackOptions?.filter ?? this.options.filter;
+    const from = waybackOptions?.from ?? this.options.from;
+    const to = waybackOptions?.to ?? this.options.to;
     const parts = [`collapse=${encodeURIComponent(collapse)}`];
 
     if (filter !== undefined) parts.push(`filter=${encodeURIComponent(filter)}`);
+    if (from !== undefined) parts.push(`from=${encodeURIComponent(from)}`);
+    if (to !== undefined) parts.push(`to=${encodeURIComponent(to)}`);
 
     return parts.join(":");
   }
@@ -71,6 +75,8 @@ export class WaybackProvider extends BaseProvider<WaybackOptions> {
       };
 
       if (options.filter !== undefined) params.filter = options.filter;
+      if (options.from !== undefined) params.from = options.from;
+      if (options.to !== undefined) params.to = options.to;
 
       const fetchOptions = await createFetchOptions(baseUrl, params, {
         retries: options.retries,

--- a/src/providers/wayback.ts
+++ b/src/providers/wayback.ts
@@ -55,6 +55,10 @@ export class WaybackProvider extends BaseProvider<WaybackOptions> {
 
   /**
    * Fetch archived snapshots from the Internet Archive Wayback Machine.
+   *
+   * The window bounds are normalized here too, not only in `Archive.snapshots`:
+   * the provider is a public export, and CDX does not read a raw ISO date as an
+   * instant.
    */
   async snapshots(domain: string, reqOptions: WaybackOptions = {}): Promise<ArchiveResponse> {
     try {
@@ -71,8 +75,10 @@ export class WaybackProvider extends BaseProvider<WaybackOptions> {
       };
 
       if (options.filter !== undefined) params.filter = options.filter;
-      if (options.from !== undefined) params.from = options.from;
-      if (options.to !== undefined) params.to = options.to;
+      const from = resolveRequestedTimestamp(options.from, "from");
+      const to = resolveRequestedTimestamp(options.to, "to");
+      if (from) params.from = from;
+      if (to) params.to = to;
 
       const fetchOptions = await createFetchOptions(baseUrl, params, {
         retries: options.retries,

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -72,6 +72,11 @@ function getCacheKeyParts(provider: CacheKeyProvider, options?: ArchiveOptions):
   const parts: string[] = [];
 
   if (options?.limit !== undefined) parts.push(`limit=${options.limit}`);
+  // A windowed fetch is served with the provider's limit lifted, so its stored
+  // response has a different shape than a naturally capped one under the same
+  // provider and domain; the bounds keep the two entries apart.
+  if (options?.from !== undefined) parts.push(`from=${encodeURIComponent(options.from)}`);
+  if (options?.to !== undefined) parts.push(`to=${encodeURIComponent(options.to)}`);
 
   const providerKey = provider.cacheKey?.(options);
   if (providerKey) parts.push(providerKey);

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -68,13 +68,18 @@ function getExpiresAt(ttl: ArchiveOptions["ttl"]): number | undefined {
   return Date.now() + Math.max(0, ttl);
 }
 
+/**
+ * Option-derived parts of one listing cache key.
+ *
+ * The window bounds belong here: a windowed fetch is served with the provider's
+ * limit lifted, so its stored response has a different shape than a naturally
+ * capped one under the same provider and domain, and the bounds keep the two
+ * entries apart.
+ */
 function getCacheKeyParts(provider: CacheKeyProvider, options?: ArchiveOptions): string[] {
   const parts: string[] = [];
 
   if (options?.limit !== undefined) parts.push(`limit=${options.limit}`);
-  // A windowed fetch is served with the provider's limit lifted, so its stored
-  // response has a different shape than a naturally capped one under the same
-  // provider and domain; the bounds keep the two entries apart.
   if (options?.from !== undefined) parts.push(`from=${encodeURIComponent(options.from)}`);
   if (options?.to !== undefined) parts.push(`to=${encodeURIComponent(options.to)}`);
 

--- a/src/tool-operations.ts
+++ b/src/tool-operations.ts
@@ -621,6 +621,12 @@ function getProviderStatuses(): ProviderStatus[] {
   ];
 }
 
+/**
+ * One-line summary above the snapshot records.
+ *
+ * The applied window is part of it: a windowed listing that reads like the
+ * archive's whole holdings invites the wrong conclusion.
+ */
 function buildSnapshotHeader(
   provider: ProviderName,
   target: string,
@@ -635,8 +641,6 @@ function buildSnapshotHeader(
   const failed = providerErrors(response);
   const failedNote = failed.length > 0 ? `; failed=${failed.length}` : "";
   const errorNote = response.error ? `; error=${truncateSingleLine(response.error, 80)}` : "";
-  // A windowed listing that reads like the archive's whole holdings invites the
-  // wrong conclusion, so the applied window is part of the answer.
   const windowNote =
     options.from !== undefined || options.to !== undefined
       ? `; window=${sanitizeField(options.from ?? "")}..${sanitizeField(options.to ?? "")}`

--- a/src/tool-operations.ts
+++ b/src/tool-operations.ts
@@ -67,6 +67,10 @@ export type ContentFormat = (typeof CONTENT_FORMATS)[number];
 
 export const CONTENT_FORMAT_HINT = `How to return the body. "text" (default) strips markup from an HTML capture and returns what a reader would see; "raw" returns the archived bytes as they were served.`;
 
+export const SNAPSHOT_FROM_HINT = `Earliest capture to list, as archive digits (YYYY through YYYYMMDDhhmmss) or an ISO 8601 date. Inclusive; a partial stamp starts the window at the beginning of the period it names.`;
+
+export const SNAPSHOT_TO_HINT = `Latest capture to list, in the same formats as "from". Inclusive; a partial stamp stretches the window to the end of the period it names, so from=2019 with to=2019 covers the whole year.`;
+
 export const DEFAULT_LIMIT = 10;
 export const MAX_LIMIT = 100;
 export const DEFAULT_MAX_CHARS = 20_000;
@@ -129,6 +133,8 @@ export interface SnapshotParams {
   user?: string;
   collapse?: string;
   filter?: string;
+  from?: string;
+  to?: string;
 }
 
 /** The queried window plus the response it came from. */
@@ -220,7 +226,7 @@ export async function snapshotArchives(
       {
         type: "text",
         text: withHeader(
-          buildSnapshotHeader(provider, target, response),
+          buildSnapshotHeader(provider, target, response, options),
           formatSnapshots(response),
         ),
       },
@@ -401,6 +407,8 @@ const TEXT_BOUNDS = {
   collapse: MAX_PARAMETER_LENGTH,
   filter: MAX_PARAMETER_LENGTH,
   timestamp: MAX_TIMESTAMP_LENGTH,
+  from: MAX_TIMESTAMP_LENGTH,
+  to: MAX_TIMESTAMP_LENGTH,
 } as const satisfies Record<string, number>;
 
 /** Validates every bounded argument an operation's parameters happen to carry. */
@@ -456,6 +464,8 @@ function buildSnapshotOptions(params: SnapshotParams, provider: ProviderName): S
   if (params.user !== undefined) options.user = params.user;
   if (params.collapse !== undefined) options.collapse = params.collapse;
   if (params.filter !== undefined) options.filter = params.filter;
+  if (params.from !== undefined) options.from = params.from;
+  if (params.to !== undefined) options.to = params.to;
 
   if (provider === "permacc") {
     const { apiKey } = getPermaccApiKeyState();
@@ -615,6 +625,7 @@ function buildSnapshotHeader(
   provider: ProviderName,
   target: string,
   response: ArchiveResponse,
+  options: SnapshotOptions,
 ): string {
   const unsupported = response._meta?.unsupportedProviders;
   const unsupportedNote =
@@ -624,12 +635,18 @@ function buildSnapshotHeader(
   const failed = providerErrors(response);
   const failedNote = failed.length > 0 ? `; failed=${failed.length}` : "";
   const errorNote = response.error ? `; error=${truncateSingleLine(response.error, 80)}` : "";
+  // A windowed listing that reads like the archive's whole holdings invites the
+  // wrong conclusion, so the applied window is part of the answer.
+  const windowNote =
+    options.from !== undefined || options.to !== undefined
+      ? `; window=${sanitizeField(options.from ?? "")}..${sanitizeField(options.to ?? "")}`
+      : "";
   // The tool is annotated open-world, so a replay from the 7-day cache has to say
   // so rather than pass for a fresh read of the archive.
   const cacheNote = response.fromCache ? "; cached" : "";
   // The target is caller-supplied and lands one line above the records, so a
   // newline in it forges a snapshot row exactly like a provider field would.
-  return `[provider=${provider}] ${response.pages.length} snapshot(s) for "${sanitizeField(target)}"${unsupportedNote}${failedNote}${errorNote}${cacheNote}`;
+  return `[provider=${provider}] ${response.pages.length} snapshot(s) for "${sanitizeField(target)}"${windowNote}${unsupportedNote}${failedNote}${errorNote}${cacheNote}`;
 }
 
 function sanitizeResponse<TResponse extends { _meta?: ArchiveResponse["_meta"] }>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,6 +167,10 @@ export interface ArchiveResponse {
 export interface ArchiveProvider {
   name: string;
   slug?: string;
+  // Initialization options the provider was created with. The aggregator reads
+  // the listing window from them, because a provider without a window-aware
+  // index has no way to apply its own init-level bounds.
+  readonly options?: ArchiveOptions;
   cacheKey?: (options?: ArchiveOptions) => string | undefined;
   snapshots: (domain: string, options?: ArchiveOptions) => Promise<ArchiveResponse>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,13 @@ export interface ArchiveOptions {
   limit?: number; // Maximum number of results to return
   signal?: AbortSignal; // Cancels in-flight provider requests
 
+  // Listing window, inclusive on both ends. Wayback-style digits (YYYY through
+  // YYYYMMDDhhmmss) or ISO 8601 dates; a partial stamp covers the whole period
+  // it names. Providers that can narrow their own query do, the rest are
+  // filtered after the fact, so the window holds across a fan-out.
+  from?: string; // Earliest capture to list
+  to?: string; // Latest capture to list
+
   // Caching options
   cache?: boolean; // Enable/disable caching
   ttl?: number; // Cache TTL in milliseconds

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,12 +3,15 @@ export interface ArchiveOptions {
   limit?: number; // Maximum number of results to return
   signal?: AbortSignal; // Cancels in-flight provider requests
 
-  // Listing window, inclusive on both ends. Wayback-style digits (YYYY through
-  // YYYYMMDDhhmmss) or ISO 8601 dates; a partial stamp covers the whole period
-  // it names. Providers that can narrow their own query do, the rest are
-  // filtered after the fact, so the window holds across a fan-out.
-  from?: string; // Earliest capture to list
-  to?: string; // Latest capture to list
+  /**
+   * Earliest capture to list. Inclusive; Wayback-style digits (YYYY through
+   * YYYYMMDDhhmmss) or an ISO 8601 date, and a partial stamp covers the whole
+   * period it names. Providers that can narrow their own query do, the rest
+   * are filtered after the fact, so the window holds across a fan-out.
+   */
+  from?: string;
+  /** Latest capture to list; the window's other inclusive edge, same formats. */
+  to?: string;
 
   // Caching options
   cache?: boolean; // Enable/disable caching
@@ -167,9 +170,11 @@ export interface ArchiveResponse {
 export interface ArchiveProvider {
   name: string;
   slug?: string;
-  // Initialization options the provider was created with. The aggregator reads
-  // the listing window from them, because a provider without a window-aware
-  // index has no way to apply its own init-level bounds.
+  /**
+   * Initialization options the provider was created with. The aggregator reads
+   * the listing window from them, because a provider without a window-aware
+   * index has no way to apply its own init-level bounds.
+   */
   readonly options?: ArchiveOptions;
   cacheKey?: (options?: ArchiveOptions) => string | undefined;
   snapshots: (domain: string, options?: ArchiveOptions) => Promise<ArchiveResponse>;

--- a/src/utils/_content.ts
+++ b/src/utils/_content.ts
@@ -123,6 +123,14 @@ export function timestampUpperBound(timestamp: string): string {
 }
 
 /**
+ * Pads a possibly partial timestamp to the lower edge of the period it names.
+ * The counterpart of {@link timestampUpperBound}, for the `from` side of a window.
+ */
+export function timestampLowerBound(timestamp: string): string {
+  return timestamp.length >= 14 ? timestamp : timestamp + "0".repeat(14 - timestamp.length);
+}
+
+/**
  * Splits an archive playback URL back into the original URL and capture stamp.
  *
  * `snapshots()` prints playback URLs, so they are what a caller holds when it

--- a/src/utils/_content.ts
+++ b/src/utils/_content.ts
@@ -98,16 +98,20 @@ function isoToWaybackDigits(value: string): string {
  * Validates a caller-supplied instant before it reaches a provider's index query.
  *
  * @param timestamp - Requested capture time, or nothing for the newest capture
+ * @param name - Which option the value came from, for the error message
  * @returns Validated timestamp digits, empty when none was requested
  * @throws When the value is not a timestamp any archive could act on
  */
-export function resolveRequestedTimestamp(timestamp: string | undefined): string {
+export function resolveRequestedTimestamp(
+  timestamp: string | undefined,
+  name = "timestamp",
+): string {
   if (timestamp === undefined || timestamp.trim() === "") return "";
 
   const normalized = toWaybackTimestamp(timestamp);
   if (!normalized) {
     throw new Error(
-      `Invalid timestamp "${timestamp}": use archive digits (YYYY to YYYYMMDDhhmmss) or an ISO 8601 date`,
+      `Invalid ${name} "${timestamp}": use archive digits (YYYY to YYYYMMDDhhmmss) or an ISO 8601 date`,
     );
   }
 

--- a/test/archive-it.test.ts
+++ b/test/archive-it.test.ts
@@ -30,6 +30,28 @@ describe("Archive-It", () => {
     );
   });
 
+  /**
+   * The provider is a public export, so a caller can hand it the ISO bounds
+   * ArchiveOptions promises without going through Archive.snapshots; the digits
+   * have to come out of the provider's own normalization then.
+   */
+  it("normalizes ISO bounds when the provider is called directly", async () => {
+    vi.mocked($fetch).mockResolvedValueOnce("");
+
+    const result = await createArchiveIt({ collection: 4399 }).snapshots("example.com", {
+      from: "2019-03-01",
+      to: "2019-06",
+    });
+
+    expect(result.success).toBe(true);
+    expect($fetch).toHaveBeenCalledWith(
+      "/4399/timemap/cdx",
+      expect.objectContaining({
+        params: expect.objectContaining({ from: "20190301", to: "201906" }),
+      }),
+    );
+  });
+
   it("lists pages from a collection CDX index", async () => {
     vi.mocked($fetch).mockResolvedValueOnce(
       [

--- a/test/archive-today.test.ts
+++ b/test/archive-today.test.ts
@@ -53,18 +53,20 @@ describe("archive.today", () => {
     );
   });
 
-  it("lifts an init-level limit while a window is active", async () => {
+  it("lifts an init-level limit for the windowed fetch and restores it after the filter", async () => {
     const mockTimemapResponse = `
     <http://archive.md/20180101000000/https://example.com/>; rel="memento"; datetime="Mon, 01 Jan 2018 00:00:00 GMT",
-    <http://archive.md/20190601000000/https://example.com/>; rel="memento"; datetime="Sat, 01 Jun 2019 00:00:00 GMT"
+    <http://archive.md/20190601000000/https://example.com/>; rel="memento"; datetime="Sat, 01 Jun 2019 00:00:00 GMT",
+    <http://archive.md/20190901000000/https://example.com/>; rel="memento"; datetime="Sun, 01 Sep 2019 00:00:00 GMT"
     `;
     vi.mocked($fetch).mockResolvedValueOnce(mockTimemapResponse);
 
     const archive = createArchiveClient(createArchiveToday({ limit: 1 }));
     const result = await archive.snapshots("example.com", { from: "2019", to: "2019" });
 
-    // With the init limit honored before the filter, the 2018 memento would
-    // consume it and the 2019 capture would read as never archived.
+    // Honored before the filter, the init limit would let the 2018 memento
+    // consume it and 2019 would read as never archived; dropped entirely, both
+    // 2019 captures would come back. It caps the filtered rows instead.
     expect(result.success).toBe(true);
     expect(result.pages.map((page) => page._meta.hash)).toEqual(["20190601000000"]);
   });

--- a/test/archive-today.test.ts
+++ b/test/archive-today.test.ts
@@ -53,6 +53,22 @@ describe("archive.today", () => {
     );
   });
 
+  it("lifts an init-level limit while a window is active", async () => {
+    const mockTimemapResponse = `
+    <http://archive.md/20180101000000/https://example.com/>; rel="memento"; datetime="Mon, 01 Jan 2018 00:00:00 GMT",
+    <http://archive.md/20190601000000/https://example.com/>; rel="memento"; datetime="Sat, 01 Jun 2019 00:00:00 GMT"
+    `;
+    vi.mocked($fetch).mockResolvedValueOnce(mockTimemapResponse);
+
+    const archive = createArchiveClient(createArchiveToday({ limit: 1 }));
+    const result = await archive.snapshots("example.com", { from: "2019", to: "2019" });
+
+    // With the init limit honored before the filter, the 2018 memento would
+    // consume it and the 2019 capture would read as never archived.
+    expect(result.success).toBe(true);
+    expect(result.pages.map((page) => page._meta.hash)).toEqual(["20190601000000"]);
+  });
+
   it("falls back to the snapshot URL stamp when a memento datetime is unreadable", async () => {
     const mockTimemapResponse = `
     <http://archive.md/20140101030405/https://example.com/>; rel="memento"; datetime="not a date",

--- a/test/archive-today.test.ts
+++ b/test/archive-today.test.ts
@@ -53,6 +53,11 @@ describe("archive.today", () => {
     );
   });
 
+  /**
+   * Honored before the filter, the init limit would let the 2018 memento
+   * consume it and 2019 would read as never archived; dropped entirely, both
+   * 2019 captures would come back. It caps the filtered rows instead.
+   */
   it("lifts an init-level limit for the windowed fetch and restores it after the filter", async () => {
     const mockTimemapResponse = `
     <http://archive.md/20180101000000/https://example.com/>; rel="memento"; datetime="Mon, 01 Jan 2018 00:00:00 GMT",
@@ -64,9 +69,6 @@ describe("archive.today", () => {
     const archive = createArchiveClient(createArchiveToday({ limit: 1 }));
     const result = await archive.snapshots("example.com", { from: "2019", to: "2019" });
 
-    // Honored before the filter, the init limit would let the 2018 memento
-    // consume it and 2019 would read as never archived; dropped entirely, both
-    // 2019 captures would come back. It caps the filtered rows instead.
     expect(result.success).toBe(true);
     expect(result.pages.map((page) => page._meta.hash)).toEqual(["20190601000000"]);
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -216,23 +216,34 @@ describe("Archive.snapshots / window", () => {
     expect(response.pages[0].timestamp).toBe("2019-06-01T00:00:00Z");
   });
 
-  it("answers different windows correctly from one unfiltered cache entry", async () => {
+  it("keeps windowed fetches out of the naturally capped cache entry", async () => {
     const provider = successProvider("cachey", [
       pageAt("cachey", "2019-03-01T00:00:00Z"),
       pageAt("cachey", "2020-03-01T00:00:00Z"),
     ]);
     const archive = createArchive(provider);
 
-    const first = await archive.snapshots("example.com", { from: "2020", to: "2020" });
-    const replayed = await archive.snapshots("example.com", { from: "2019", to: "2019" });
+    const natural = await archive.snapshots("example.com");
+    const windowed = await archive.snapshots("example.com", { from: "2019", to: "2019" });
 
-    // The stored entry is the provider's unfiltered answer, so a second window
-    // replays it and filters on the way out instead of inheriting the first
-    // window's rows.
-    expect(provider.snapshots).toHaveBeenCalledTimes(1);
-    expect(first.pages.map((page) => page.timestamp)).toEqual(["2020-03-01T00:00:00Z"]);
-    expect(replayed.fromCache).toBe(true);
-    expect(replayed.pages.map((page) => page.timestamp)).toEqual(["2019-03-01T00:00:00Z"]);
+    // The natural entry may have been capped by the provider's own limit, so a
+    // windowed request must not replay it: the window travels in the cache key
+    // and earns its own fetch, made with the limit lifted.
+    expect(provider.snapshots).toHaveBeenCalledTimes(2);
+    expect(natural.pages).toHaveLength(2);
+    expect(windowed.fromCache).toBeUndefined();
+    expect(windowed.pages.map((page) => page.timestamp)).toEqual(["2019-03-01T00:00:00Z"]);
+  });
+
+  it("rejects an init-level bound no archive could act on", async () => {
+    const provider: ArchiveProvider = {
+      ...successProvider("timemap", []),
+      options: { from: "last tuesday" },
+    };
+    const archive = createArchive(provider);
+
+    await expect(archive.snapshots("example.com")).rejects.toThrow('Invalid from "last tuesday"');
+    expect(provider.snapshots).not.toHaveBeenCalled();
   });
 
   it("caps a windowed fan-out after the newest-first merge, not per provider", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -176,6 +176,65 @@ describe("Archive.snapshots / window", () => {
     expect(response.pages.map((page) => page._meta.provider)).toEqual(["a"]);
   });
 
+  it("honors a window configured on the provider itself", async () => {
+    // providers.all({ from: "2019" }) hands the bounds to every factory, and a
+    // provider without a window-aware index cannot apply them on its own.
+    const provider: ArchiveProvider = {
+      ...successProvider("timemap", [
+        pageAt("timemap", "2018-11-05T00:00:00Z"),
+        pageAt("timemap", "2019-03-01T12:00:00Z"),
+        pageAt("timemap", "2020-01-01T00:00:00Z"),
+      ]),
+      options: { from: "2019", to: "2019" },
+    };
+    const archive = createArchive(provider);
+
+    const response = await archive.snapshots("example.com");
+
+    expect(response.pages.map((page) => page.timestamp)).toEqual(["2019-03-01T12:00:00Z"]);
+  });
+
+  it("lifts the provider limit while a window is active and caps after filtering", async () => {
+    const provider = successProvider("timemap", [
+      pageAt("timemap", "2020-01-01T00:00:00Z"),
+      pageAt("timemap", "2019-06-01T00:00:00Z"),
+      pageAt("timemap", "2019-03-01T00:00:00Z"),
+    ]);
+    const archive = createArchive(provider);
+
+    const response = await archive.snapshots("example.com", {
+      from: "2019",
+      to: "2019",
+      limit: 1,
+    });
+
+    // A provider-side limit would cap the rows before the filter and turn a
+    // tight limit into a false "nothing captured in this window".
+    const providerOptions = vi.mocked(provider.snapshots).mock.calls[0][1];
+    expect(providerOptions?.limit).toBeUndefined();
+    expect(response.pages).toHaveLength(1);
+    expect(response.pages[0].timestamp).toBe("2019-06-01T00:00:00Z");
+  });
+
+  it("answers different windows correctly from one unfiltered cache entry", async () => {
+    const provider = successProvider("cachey", [
+      pageAt("cachey", "2019-03-01T00:00:00Z"),
+      pageAt("cachey", "2020-03-01T00:00:00Z"),
+    ]);
+    const archive = createArchive(provider);
+
+    const first = await archive.snapshots("example.com", { from: "2020", to: "2020" });
+    const replayed = await archive.snapshots("example.com", { from: "2019", to: "2019" });
+
+    // The stored entry is the provider's unfiltered answer, so a second window
+    // replays it and filters on the way out instead of inheriting the first
+    // window's rows.
+    expect(provider.snapshots).toHaveBeenCalledTimes(1);
+    expect(first.pages.map((page) => page.timestamp)).toEqual(["2020-03-01T00:00:00Z"]);
+    expect(replayed.fromCache).toBe(true);
+    expect(replayed.pages.map((page) => page.timestamp)).toEqual(["2019-03-01T00:00:00Z"]);
+  });
+
   it("rejects an inverted window before any provider is queried", async () => {
     const provider = successProvider("timemap", []);
     const archive = createArchive(provider);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -133,6 +133,10 @@ describe("Archive.snapshots / window", () => {
     _meta: { provider: slug },
   });
 
+  /**
+   * The provider still receives the window, as validated digits, so an index
+   * that understands it narrows its own query.
+   */
   it("drops captures outside the window from a provider that cannot narrow its query", async () => {
     const provider = successProvider("timemap", [
       pageAt("timemap", "2018-11-05T00:00:00Z"),
@@ -145,8 +149,6 @@ describe("Archive.snapshots / window", () => {
 
     expect(response.success).toBe(true);
     expect(response.pages.map((page) => page.timestamp)).toEqual(["2019-03-01T12:00:00Z"]);
-    // The provider still receives the window, as validated digits, so an index
-    // that understands it narrows its own query.
     expect(provider.snapshots).toHaveBeenCalledWith(
       "example.com",
       expect.objectContaining({ from: "20190101", to: "201906" }),
@@ -176,9 +178,11 @@ describe("Archive.snapshots / window", () => {
     expect(response.pages.map((page) => page._meta.provider)).toEqual(["a"]);
   });
 
+  /**
+   * providers.all({ from: "2019" }) hands the bounds to every factory, and a
+   * provider without a window-aware index cannot apply them on its own.
+   */
   it("honors a window configured on the provider itself", async () => {
-    // providers.all({ from: "2019" }) hands the bounds to every factory, and a
-    // provider without a window-aware index cannot apply them on its own.
     const provider: ArchiveProvider = {
       ...successProvider("timemap", [
         pageAt("timemap", "2018-11-05T00:00:00Z"),
@@ -194,6 +198,10 @@ describe("Archive.snapshots / window", () => {
     expect(response.pages.map((page) => page.timestamp)).toEqual(["2019-03-01T12:00:00Z"]);
   });
 
+  /**
+   * A provider-side limit would cap the rows before the filter and turn a
+   * tight limit into a false "nothing captured in this window".
+   */
   it("lifts the provider limit while a window is active and caps after filtering", async () => {
     const provider = successProvider("timemap", [
       pageAt("timemap", "2020-01-01T00:00:00Z"),
@@ -208,14 +216,17 @@ describe("Archive.snapshots / window", () => {
       limit: 1,
     });
 
-    // A provider-side limit would cap the rows before the filter and turn a
-    // tight limit into a false "nothing captured in this window".
     const providerOptions = vi.mocked(provider.snapshots).mock.calls[0][1];
     expect(providerOptions?.limit).toBeUndefined();
     expect(response.pages).toHaveLength(1);
     expect(response.pages[0].timestamp).toBe("2019-06-01T00:00:00Z");
   });
 
+  /**
+   * The natural entry may have been capped by the provider's own limit, so a
+   * windowed request must not replay it: the window travels in the cache key
+   * and earns its own fetch, made with the limit lifted.
+   */
   it("keeps windowed fetches out of the naturally capped cache entry", async () => {
     const provider = successProvider("cachey", [
       pageAt("cachey", "2019-03-01T00:00:00Z"),
@@ -226,9 +237,6 @@ describe("Archive.snapshots / window", () => {
     const natural = await archive.snapshots("example.com");
     const windowed = await archive.snapshots("example.com", { from: "2019", to: "2019" });
 
-    // The natural entry may have been capped by the provider's own limit, so a
-    // windowed request must not replay it: the window travels in the cache key
-    // and earns its own fetch, made with the limit lifted.
     expect(provider.snapshots).toHaveBeenCalledTimes(2);
     expect(natural.pages).toHaveLength(2);
     expect(windowed.fromCache).toBeUndefined();
@@ -246,9 +254,11 @@ describe("Archive.snapshots / window", () => {
     expect(provider.snapshots).not.toHaveBeenCalled();
   });
 
+  /**
+   * Wayback answers oldest first; a cap taken in that order would keep January
+   * and discard the December capture the merge sorts to the top.
+   */
   it("caps a windowed fan-out after the newest-first merge, not per provider", async () => {
-    // Wayback answers oldest first; a cap taken in that order would keep
-    // January and discard the December capture the merge sorts to the top.
     const oldestFirst = successProvider("wayback-like", [
       pageAt("wayback-like", "2019-01-01T00:00:00Z"),
       pageAt("wayback-like", "2019-12-01T00:00:00Z"),

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -221,6 +221,34 @@ describe("Archive.snapshots / window", () => {
   });
 
   /**
+   * The tool surfaces initialize every provider with the same options they
+   * pass as the request, so an init-level limit equal to the request limit
+   * must not cap each provider in its own order before the newest-first merge.
+   */
+  it("lets a request limit outrank an init-level one in a windowed fan-out", async () => {
+    const oldestFirst: ArchiveProvider = {
+      ...successProvider("wayback-like", [
+        pageAt("wayback-like", "2019-01-01T00:00:00Z"),
+        pageAt("wayback-like", "2019-12-01T00:00:00Z"),
+      ]),
+      options: { limit: 1 },
+    };
+    const empty: ArchiveProvider = {
+      ...successProvider("other", []),
+      options: { limit: 1 },
+    };
+    const archive = createArchive([oldestFirst, empty]);
+
+    const response = await archive.snapshots("example.com", {
+      from: "2019",
+      to: "2019",
+      limit: 1,
+    });
+
+    expect(response.pages.map((page) => page.timestamp)).toEqual(["2019-12-01T00:00:00Z"]);
+  });
+
+  /**
    * The natural entry may have been capped by the provider's own limit, so a
    * windowed request must not replay it: the window travels in the cache key
    * and earns its own fetch, made with the limit lifted.

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -127,10 +127,8 @@ describe("Archive.resolveProviders", () => {
 
 describe("Archive.snapshots / window", () => {
   const pageAt = (slug: string, timestamp: string): ArchivedPage => ({
-    url: "https://example.com",
+    ...samplePage(slug),
     timestamp,
-    snapshot: `https://archive.example/${slug}/${timestamp}`,
-    _meta: { provider: slug },
   });
 
   /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -235,6 +235,38 @@ describe("Archive.snapshots / window", () => {
     expect(replayed.pages.map((page) => page.timestamp)).toEqual(["2019-03-01T00:00:00Z"]);
   });
 
+  it("caps a windowed fan-out after the newest-first merge, not per provider", async () => {
+    // Wayback answers oldest first; a cap taken in that order would keep
+    // January and discard the December capture the merge sorts to the top.
+    const oldestFirst = successProvider("wayback-like", [
+      pageAt("wayback-like", "2019-01-01T00:00:00Z"),
+      pageAt("wayback-like", "2019-12-01T00:00:00Z"),
+    ]);
+    const empty = successProvider("other", []);
+    const archive = createArchive([oldestFirst, empty]);
+
+    const response = await archive.snapshots("example.com", {
+      from: "2019",
+      to: "2019",
+      limit: 1,
+    });
+
+    expect(response.pages.map((page) => page.timestamp)).toEqual(["2019-12-01T00:00:00Z"]);
+  });
+
+  it("rejects an inverted window assembled across the option cascade", async () => {
+    const provider: ArchiveProvider = {
+      ...successProvider("timemap", []),
+      options: { from: "2020" },
+    };
+    const archive = createArchive(provider);
+
+    await expect(archive.snapshots("example.com", { to: "2019" })).rejects.toThrow(
+      "Window is inverted",
+    );
+    expect(provider.snapshots).not.toHaveBeenCalled();
+  });
+
   it("rejects an inverted window before any provider is queried", async () => {
     const provider = successProvider("timemap", []);
     const archive = createArchive(provider);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -125,6 +125,78 @@ describe("Archive.resolveProviders", () => {
   });
 });
 
+describe("Archive.snapshots / window", () => {
+  const pageAt = (slug: string, timestamp: string): ArchivedPage => ({
+    url: "https://example.com",
+    timestamp,
+    snapshot: `https://archive.example/${slug}/${timestamp}`,
+    _meta: { provider: slug },
+  });
+
+  it("drops captures outside the window from a provider that cannot narrow its query", async () => {
+    const provider = successProvider("timemap", [
+      pageAt("timemap", "2018-11-05T00:00:00Z"),
+      pageAt("timemap", "2019-03-01T12:00:00Z"),
+      pageAt("timemap", "2020-01-01T00:00:00Z"),
+    ]);
+    const archive = createArchive(provider);
+
+    const response = await archive.snapshots("example.com", { from: "2019-01-01", to: "2019-06" });
+
+    expect(response.success).toBe(true);
+    expect(response.pages.map((page) => page.timestamp)).toEqual(["2019-03-01T12:00:00Z"]);
+    // The provider still receives the window, as validated digits, so an index
+    // that understands it narrows its own query.
+    expect(provider.snapshots).toHaveBeenCalledWith(
+      "example.com",
+      expect.objectContaining({ from: "20190101", to: "201906" }),
+    );
+  });
+
+  it("keeps both window edges inclusive", async () => {
+    const provider = successProvider("timemap", [
+      pageAt("timemap", "2019-01-01T00:00:00Z"),
+      pageAt("timemap", "2019-12-31T23:59:59Z"),
+    ]);
+    const archive = createArchive(provider);
+
+    const response = await archive.snapshots("example.com", { from: "2019", to: "2019" });
+
+    expect(response.pages).toHaveLength(2);
+  });
+
+  it("filters every provider of a fan-out before their pages merge", async () => {
+    const inWindow = successProvider("a", [pageAt("a", "2019-05-01T00:00:00Z")]);
+    const outOfWindow = successProvider("b", [pageAt("b", "2022-05-01T00:00:00Z")]);
+    const archive = createArchive([inWindow, outOfWindow]);
+
+    const response = await archive.snapshots("example.com", { from: "2019", to: "2019" });
+
+    expect(response.success).toBe(true);
+    expect(response.pages.map((page) => page._meta.provider)).toEqual(["a"]);
+  });
+
+  it("rejects an inverted window before any provider is queried", async () => {
+    const provider = successProvider("timemap", []);
+    const archive = createArchive(provider);
+
+    await expect(archive.snapshots("example.com", { from: "2020", to: "2019" })).rejects.toThrow(
+      "Window is inverted",
+    );
+    expect(provider.snapshots).not.toHaveBeenCalled();
+  });
+
+  it("rejects a window edge no archive could act on", async () => {
+    const provider = successProvider("timemap", []);
+    const archive = createArchive(provider);
+
+    await expect(archive.snapshots("example.com", { from: "last tuesday" })).rejects.toThrow(
+      'Invalid from "last tuesday"',
+    );
+    expect(provider.snapshots).not.toHaveBeenCalled();
+  });
+});
+
 describe("combineResults / deduplication", () => {
   it("keeps the first provider page for duplicate URL and timestamp before limiting", async () => {
     const first = successProvider("shared", [
@@ -163,9 +235,7 @@ describe("combineResults / deduplication", () => {
 
     const response = await archive.snapshots("example.com");
 
-    expect(response.pages.map((page) => page.snapshot)).toEqual([
-      "https://archive.example/first",
-    ]);
+    expect(response.pages.map((page) => page.snapshot)).toEqual(["https://archive.example/first"]);
   });
 
   it("preserves distinct captures from the same provider at the same timestamp", async () => {
@@ -283,12 +353,8 @@ describe("archive.getPages", () => {
 
   // Path 4: multi all success → returns merged pages (covered indirectly elsewhere)
   it("multi-provider all success: returns merged sorted pages", async () => {
-    const a = successProvider("a", [
-      { ...samplePage("a"), timestamp: "2023-01-02T00:00:00Z" },
-    ]);
-    const b = successProvider("b", [
-      { ...samplePage("b"), timestamp: "2023-01-01T00:00:00Z" },
-    ]);
+    const a = successProvider("a", [{ ...samplePage("a"), timestamp: "2023-01-02T00:00:00Z" }]);
+    const b = successProvider("b", [{ ...samplePage("b"), timestamp: "2023-01-01T00:00:00Z" }]);
     const archive = createArchive([a, b]);
     const pages = await archive.getPages("example.com");
     expect(pages).toHaveLength(2);
@@ -299,10 +365,7 @@ describe("archive.getPages", () => {
 
   // Path 5: multi all error → throw generic Error with joined messages
   it("multi-provider all error: throws generic Error with joined messages", async () => {
-    const archive = createArchive([
-      errorProvider("a", "down a"),
-      errorProvider("b", "down b"),
-    ]);
+    const archive = createArchive([errorProvider("a", "down a"), errorProvider("b", "down b")]);
     const error = await captureThrow(archive.getPages("example.com"));
     expect(error).toBeInstanceOf(Error);
     expect(error).not.toBeInstanceOf(UnsupportedOperationError);

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -170,6 +170,33 @@ describe("archives MCP server", () => {
     expect(response.structuredContent).toBeUndefined();
   });
 
+  it("applies the requested window and names it in the header", async () => {
+    stubProvider(
+      providersMock.wayback,
+      success([
+        page(),
+        page({
+          timestamp: "2019-03-01T12:00:00.000Z",
+          snapshot: "https://web.archive.org/web/20190301120000/https://example.com/",
+        }),
+      ]),
+    );
+    const client = await connectTestClient();
+
+    const response = await client.callTool({
+      name: "archives_snapshots",
+      arguments: { target: "example.com", provider: "wayback", from: "2019", to: "2019-06" },
+    });
+
+    expect(response.isError).toBeUndefined();
+    const rendered = text(response.content);
+    expect(rendered).toContain('1 snapshot(s) for "example.com"; window=2019..2019-06');
+    expect(rendered).toContain("2019-03-01T12:00:00.000Z");
+    // The stubbed provider ignored the window, the way a timemap backend would,
+    // so the out-of-window capture has to be filtered rather than listed.
+    expect(rendered).not.toContain("2024-01-02");
+  });
+
   it("names providers that cannot answer instead of dropping them", async () => {
     providersMock.all.mockResolvedValue([
       { name: "wayback", slug: "wayback", snapshots: vi.fn().mockResolvedValue(success([page()])) },

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -170,6 +170,10 @@ describe("archives MCP server", () => {
     expect(response.structuredContent).toBeUndefined();
   });
 
+  /**
+   * The stubbed provider ignores the window, the way a timemap backend would,
+   * so the out-of-window capture has to be filtered rather than listed.
+   */
   it("applies the requested window and names it in the header", async () => {
     stubProvider(
       providersMock.wayback,
@@ -192,8 +196,6 @@ describe("archives MCP server", () => {
     const rendered = text(response.content);
     expect(rendered).toContain('1 snapshot(s) for "example.com"; window=2019..2019-06');
     expect(rendered).toContain("2019-03-01T12:00:00.000Z");
-    // The stubbed provider ignored the window, the way a timemap backend would,
-    // so the out-of-window capture has to be filtered rather than listed.
     expect(rendered).not.toContain("2024-01-02");
   });
 

--- a/test/omp-extension.test.ts
+++ b/test/omp-extension.test.ts
@@ -248,6 +248,7 @@ describe("archives OMP extension", () => {
     expect(rendered).not.toMatch(/[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/u);
   });
 
+  /** A windowed call must not preview like a full-archive scan. */
   it("shows the requested window in the call preview", () => {
     const tool = requireTool(registerExtension().tools, "archives");
     const renderCall = tool.renderCall;
@@ -266,7 +267,6 @@ describe("archives OMP extension", () => {
     );
     const rendered = component.render(200).join("\n");
 
-    // A windowed call must not preview like a full-archive scan.
     expect(rendered).toContain("from=2019");
     expect(rendered).toContain("to=2019-06");
   });

--- a/test/omp-extension.test.ts
+++ b/test/omp-extension.test.ts
@@ -113,6 +113,34 @@ describe("archives OMP extension", () => {
     expect(accepts(tool, { target: "example.com", provider: "waybackmachine" })).toBe(false);
   });
 
+  it("narrows a Wayback query to the requested window", async () => {
+    vi.mocked($fetch).mockResolvedValueOnce([["original", "timestamp", "statuscode"]]);
+    const tool = requireTool(registerExtension().tools, "archives");
+
+    expect(accepts(tool, { target: "example.com", from: "2019", to: "2019-06" })).toBe(true);
+
+    await tool.execute(
+      "test",
+      {
+        target: "example.com",
+        provider: "wayback",
+        from: "2019-03-01",
+        to: "2019-06",
+        cache: false,
+      },
+      undefined,
+      undefined,
+      unusedContext,
+    );
+
+    expect($fetch).toHaveBeenCalledWith(
+      "/cdx/search/cdx",
+      expect.objectContaining({
+        params: expect.objectContaining({ from: "20190301", to: "201906" }),
+      }),
+    );
+  });
+
   it("dispatches Archive-It requests with the required collection", async () => {
     vi.mocked($fetch).mockResolvedValueOnce("https://example.com/ 20220101000000 200");
     const tool = requireTool(registerExtension().tools, "archives");

--- a/test/omp-extension.test.ts
+++ b/test/omp-extension.test.ts
@@ -248,6 +248,29 @@ describe("archives OMP extension", () => {
     expect(rendered).not.toMatch(/[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/u);
   });
 
+  it("shows the requested window in the call preview", () => {
+    const tool = requireTool(registerExtension().tools, "archives");
+    const renderCall = tool.renderCall;
+    if (!renderCall) throw new Error("archives has no call renderer");
+
+    type RenderCall = NonNullable<ToolDefinition["renderCall"]>;
+    type RenderTheme = Parameters<RenderCall>[2];
+    const theme = {
+      bold: (text: string) => text,
+      fg: (_color: string, text: string) => text,
+    } as unknown as RenderTheme;
+    const component = renderCall(
+      { target: "example.com", from: "2019", to: "2019-06" },
+      { expanded: false, isPartial: false },
+      theme,
+    );
+    const rendered = component.render(200).join("\n");
+
+    // A windowed call must not preview like a full-archive scan.
+    expect(rendered).toContain("from=2019");
+    expect(rendered).toContain("to=2019-06");
+  });
+
   it("keeps a newline in an argument from opening a second preview line", () => {
     const tool = requireTool(registerExtension().tools, "archives");
     const renderCall = tool.renderCall;

--- a/test/pi-extension.test.ts
+++ b/test/pi-extension.test.ts
@@ -18,6 +18,8 @@ import {
   MAX_LIMIT,
   PROVIDER_HINT,
   PROVIDER_INPUTS,
+  SNAPSHOT_FROM_HINT,
+  SNAPSHOT_TO_HINT,
 } from "../src/tool-operations";
 import type { ArchiveContentResponse, ArchiveResponse } from "../src/types";
 
@@ -276,11 +278,35 @@ describe("Pi extension", () => {
     expect(properties["limit"]).toMatchObject({ minimum: 1, maximum: MAX_LIMIT });
     expect(properties["limit"]?.["description"]).toContain(`Defaults to ${DEFAULT_LIMIT}.`);
     expect(properties["provider"]?.["description"]).toBe(PROVIDER_HINT);
+    expect(properties["from"]?.["description"]).toBe(SNAPSHOT_FROM_HINT);
+    expect(properties["to"]?.["description"]).toBe(SNAPSHOT_TO_HINT);
     // Every spelling normalizeProvider accepts has to be offered, and no other.
     const offered = ((properties["provider"]?.["anyOf"] ?? []) as Array<{ const: string }>).map(
       (member) => member.const,
     );
     expect(offered.sort()).toEqual([...PROVIDER_INPUTS].sort());
+  });
+
+  it("passes the window to the provider as validated digits", async () => {
+    archivesMock.snapshots.mockResolvedValue({
+      success: true,
+      pages: [],
+      _meta: { source: "wayback", provider: "wayback" },
+    } satisfies ArchiveResponse);
+    const tool = getExecutableTool(loadExtension(), "archives");
+
+    await tool.execute(
+      "test",
+      { target: "example.com", provider: "wayback", from: "2019-03-01", to: "2019-06" },
+      undefined,
+      undefined,
+      {} as ExtensionContext,
+    );
+
+    expect(archivesMock.snapshots).toHaveBeenCalledWith(
+      "example.com",
+      expect.objectContaining({ from: "20190301", to: "201906" }),
+    );
   });
 
   it("does not expose arbitrary API-key or environment-variable parameters", () => {

--- a/test/wayback.test.ts
+++ b/test/wayback.test.ts
@@ -117,6 +117,28 @@ describe("wayback machine", () => {
   });
 
   /**
+   * The provider is a public export, so a caller can hand it the ISO bounds
+   * ArchiveOptions promises without going through Archive.snapshots; the digits
+   * have to come out of the provider's own normalization then.
+   */
+  it("normalizes ISO bounds when the provider is called directly", async () => {
+    vi.mocked($fetch).mockResolvedValueOnce([["original", "timestamp", "statuscode"]]);
+
+    const result = await createWayback().snapshots("example.com", {
+      from: "2019-03-01",
+      to: "2019-06",
+    });
+
+    expect(result.success).toBe(true);
+    expect($fetch).toHaveBeenCalledWith(
+      "/cdx/search/cdx",
+      expect.objectContaining({
+        params: expect.objectContaining({ from: "20190301", to: "201906" }),
+      }),
+    );
+  });
+
+  /**
    * Left raw, the init-level date would reach CDX as from=2019-03-01, which
    * the index does not read as an instant.
    */

--- a/test/wayback.test.ts
+++ b/test/wayback.test.ts
@@ -116,14 +116,16 @@ describe("wayback machine", () => {
     );
   });
 
+  /**
+   * Left raw, the init-level date would reach CDX as from=2019-03-01, which
+   * the index does not read as an instant.
+   */
   it("normalizes an init-level ISO bound before it reaches the CDX query", async () => {
     vi.mocked($fetch).mockResolvedValueOnce([["original", "timestamp", "statuscode"]]);
 
     const archive = createArchive(createWayback({ from: "2019-03-01" }));
     const result = await archive.snapshots("example.com");
 
-    // Left raw, the init-level date would reach CDX as from=2019-03-01, which
-    // the index does not read as an instant.
     expect(result.success).toBe(true);
     expect($fetch).toHaveBeenCalledWith(
       "/cdx/search/cdx",
@@ -133,6 +135,7 @@ describe("wayback machine", () => {
     );
   });
 
+  /** The third query repeats the first window, so it must replay that answer rather than the other window's entry or a fresh fetch. */
   it("separates cache entries by window", async () => {
     vi.mocked($fetch)
       .mockResolvedValueOnce([
@@ -151,8 +154,6 @@ describe("wayback machine", () => {
 
     expect(first.pages[0].url).toBe("https://example.com/2019");
     expect(second.pages[0].url).toBe("https://example.com/2020");
-    // The third query repeats the first window, so it must replay that answer
-    // rather than the other window's entry or a fresh fetch.
     expect(replayed.fromCache).toBe(true);
     expect(replayed.pages[0].url).toBe("https://example.com/2019");
     expect($fetch).toHaveBeenCalledTimes(2);

--- a/test/wayback.test.ts
+++ b/test/wayback.test.ts
@@ -116,6 +116,23 @@ describe("wayback machine", () => {
     );
   });
 
+  it("normalizes an init-level ISO bound before it reaches the CDX query", async () => {
+    vi.mocked($fetch).mockResolvedValueOnce([["original", "timestamp", "statuscode"]]);
+
+    const archive = createArchive(createWayback({ from: "2019-03-01" }));
+    const result = await archive.snapshots("example.com");
+
+    // Left raw, the init-level date would reach CDX as from=2019-03-01, which
+    // the index does not read as an instant.
+    expect(result.success).toBe(true);
+    expect($fetch).toHaveBeenCalledWith(
+      "/cdx/search/cdx",
+      expect.objectContaining({
+        params: expect.objectContaining({ from: "20190301" }),
+      }),
+    );
+  });
+
   it("separates cache entries by window", async () => {
     vi.mocked($fetch)
       .mockResolvedValueOnce([

--- a/test/wayback.test.ts
+++ b/test/wayback.test.ts
@@ -101,6 +101,46 @@ describe("wayback machine", () => {
     );
   });
 
+  it("narrows the CDX query to the requested window", async () => {
+    vi.mocked($fetch).mockResolvedValueOnce([["original", "timestamp", "statuscode"]]);
+
+    const archive = createArchive(createWayback());
+    const result = await archive.snapshots("example.com", { from: "2019-03-01", to: "2019-06" });
+
+    expect(result.success).toBe(true);
+    expect($fetch).toHaveBeenCalledWith(
+      "/cdx/search/cdx",
+      expect.objectContaining({
+        params: expect.objectContaining({ from: "20190301", to: "201906" }),
+      }),
+    );
+  });
+
+  it("separates cache entries by window", async () => {
+    vi.mocked($fetch)
+      .mockResolvedValueOnce([
+        ["original", "timestamp", "statuscode"],
+        ["https://example.com/2019", "20190301000000", "200"],
+      ])
+      .mockResolvedValueOnce([
+        ["original", "timestamp", "statuscode"],
+        ["https://example.com/2020", "20200301000000", "200"],
+      ]);
+
+    const archive = createArchive(createWayback());
+    const first = await archive.snapshots("example.com", { from: "2019", to: "2019" });
+    const second = await archive.snapshots("example.com", { from: "2020", to: "2020" });
+    const replayed = await archive.snapshots("example.com", { from: "2019", to: "2019" });
+
+    expect(first.pages[0].url).toBe("https://example.com/2019");
+    expect(second.pages[0].url).toBe("https://example.com/2020");
+    // The third query repeats the first window, so it must replay that answer
+    // rather than the other window's entry or a fresh fetch.
+    expect(replayed.fromCache).toBe(true);
+    expect(replayed.pages[0].url).toBe("https://example.com/2019");
+    expect($fetch).toHaveBeenCalledTimes(2);
+  });
+
   it("separates cache entries for CDX collapse and filter options", async () => {
     vi.mocked($fetch)
       .mockResolvedValueOnce([
@@ -116,9 +156,7 @@ describe("wayback machine", () => {
         ["https://example.com/not-found", "20220101000000", "200"],
       ]);
 
-    const archive = createArchive(
-      createWayback({ collapse: "digest", filter: "statuscode:200" }),
-    );
+    const archive = createArchive(createWayback({ collapse: "digest", filter: "statuscode:200" }));
     const byYear: WaybackOptions = { collapse: "timestamp:4" };
     const notFound: WaybackOptions = { filter: "statuscode:404" };
 


### PR DESCRIPTION
`content()` reads a page as it stood in March 2019, but `snapshots()` can't list what was captured back then, the listing always answers from the whole archive. Annoying asymmetry when digging through a site's history. So listings take `from`/`to` now: pushed into the CDX query where the index understands it (Wayback, Archive-It) and filtered after the fact everywhere else, so `provider=all` can't mix 2024 rows into a 2019 question. Both edges inclusive, partial stamps cover the whole period they name, same formats `timestamp` already takes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/agntn/archives/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

