### PR TITLE
fix: build before type-checking the extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
       - run: pnpm install
       - run: pnpm lint
       - run: pnpm test:types
-      - run: pnpm build
       - run: pnpm --dir playground build
       - run: pnpm vitest --coverage
       - uses: codecov/codecov-action@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ archives/
 - **Linting**: `oxlint` only; ESLint was removed intentionally.
 - **Build**: `obuild` reads `build.config.ts` → `dist/`. Four inputs in **one** bundle entry so the entrypoint, the CLI, the MCP server and the executors share chunks instead of each carrying a private copy of the provider factory.
 - **One executor per operation**: MCP, Pi and OMP all call `src/tool-operations.ts`. A surface owns only its schema, its call rendering and its result envelope. Schema metadata (`PROVIDER_HINT`, limits) is restated per surface because parameters are declared before the executors can be loaded — the extension tests guard it against drift.
-- **OMP loader imports stay literal**: `existsSync(src)` chooses between `import("../../../src/tool-operations.ts")` and `import("../../../dist/tool-operations.mjs")`. Never `import(url.href)`.
+- **OMP loader imports stay literal**: `existsSync(src)` chooses between `import("../../../src/tool-operations.ts")` and `import("../../../dist/tool-operations.mjs")`. Never `import(url.href)`. `tsc` resolves that dist specifier, so `test:types` builds before it type-checks.
 - **MCP result is text only**: `details` never reaches an MCP client, so anything a caller needs for the next call belongs in `content[].text`.
 - **Listing fans out, reading falls back**: `snapshots()` queries providers in parallel and merges; `content()` walks them in order and stops at the first body, because there is one page to read rather than a set to merge. Providers that failed or cannot read are reported beside the body in `_meta`.
 - **A capture is read raw or not at all**: bodies come from `id_` playback (Wayback, Archive-It) or a WARC byte range (Common Crawl). An archive that only serves its own rendition of a page returns `createUnsupportedContentResponse` with the reason instead.
@@ -137,7 +137,7 @@ archives/
 pnpm install          # install deps
 pnpm dev              # vitest watch mode
 pnpm test             # lint + type-check + vitest with coverage
-pnpm test:types       # tsc lib + packages/pi/extensions type checks
+pnpm test:types       # build + tsc over lib and both extension surfaces
 pnpm lint             # oxlint
 pnpm lint:fix         # oxlint --fix
 pnpm build            # obuild (build.config.ts) → dist/

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "fmt": "oxlint . --fix && oxfmt .",
     "fmt:check": "oxfmt --check .",
     "test": "pnpm lint && pnpm test:types && vitest run --coverage",
-    "test:types": "tsc --noEmit --skipLibCheck && tsc --noEmit --skipLibCheck -p tsconfig.extensions.json",
+    "test:types": "pnpm build && tsc --noEmit --skipLibCheck && tsc --noEmit --skipLibCheck -p tsconfig.extensions.json",
     "build": "obuild",
     "prepack": "pnpm build",
     "release": "pnpm test && changelogen --release --push && pnpm publish"


### PR DESCRIPTION
`main` has been red since #34: CI type-checks before it builds, and `tsc` really does resolve the literal `dist/tool-operations.mjs` specifier, so a fresh checkout has nothing to resolve there. `pnpm test` on a clean clone breaks the same way. Building first also gets rid of the stale `dist` case, where `tsc` reports missing exports against source that is perfectly fine, which is a confusing way to fail.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/agntn/archives/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

