### PR TITLE
fix: list the newest Archive.today capture

### DIFF
--- a/src/providers/archive-today.ts
+++ b/src/providers/archive-today.ts
@@ -35,6 +35,11 @@ export class ArchiveTodayProvider extends BaseProvider<ArchiveTodayOptions> {
    * snapshot URL names the same instant, so its stamp is the fallback. Stamping
    * "now" instead would push the row above every real capture once a merged
    * response sorts newest-first; a row with no readable time at all is dropped.
+   *
+   * The timemap labels its newest row `last memento` and a lone capture
+   * `first last memento`, so the match takes any first/last qualifiers;
+   * requiring a bare `memento` would drop the newest capture from every
+   * listing.
    */
   async snapshots(domain: string, reqOptions: ArchiveTodayOptions = {}): Promise<ArchiveResponse> {
     const cleanDomain = normalizeDomain(domain, false);
@@ -58,7 +63,7 @@ export class ArchiveTodayProvider extends BaseProvider<ArchiveTodayOptions> {
       // <http://archive.md/20140101030405/https://example.com/>; rel="memento"; datetime="Wed, 01 Jan 2014 03:04:05 GMT"
       const pages: ArchivedPage[] = [];
       const mementoRegex =
-        /<(https?:\/\/archive\.(?:is|today|md|ph)\/([0-9]{8,14})\/(?:https?:\/\/)?([^>]+))>;\s*rel="(?:first\s+)?memento";\s*datetime="([^"]+)"/g;
+        /<(https?:\/\/archive\.(?:is|today|md|ph)\/([0-9]{8,14})\/(?:https?:\/\/)?([^>]+))>;\s*rel="(?:(?:first|last)\s+)*memento";\s*datetime="([^"]+)"/g;
 
       let mementoMatch;
       let index = 0;

--- a/test/archive-today.test.ts
+++ b/test/archive-today.test.ts
@@ -95,6 +95,48 @@ describe("archive.today", () => {
     expect(result.pages[1]._meta.position).toBe(1);
   });
 
+  /**
+   * The live timemap labels its newest row `rel="last memento"` and a lone
+   * capture `rel="first last memento"`, so a match accepting only the `first`
+   * qualifier silently drops the newest capture from every listing.
+   */
+  it("keeps the memento labeled last", async () => {
+    const mockTimemapResponse = `
+    <https://example.com/>; rel="original",
+    <http://archive.md/timegate/https://example.com/>; rel="timegate",
+    <http://archive.md/20020120142510/http://example.com/>; rel="first memento"; datetime="Sun, 20 Jan 2002 14:25:10 GMT",
+    <http://archive.md/20140101030405/https://example.com/>; rel="memento"; datetime="Wed, 01 Jan 2014 03:04:05 GMT",
+    <http://archive.md/20160810200921/https://example.com/>; rel="last memento"; datetime="Wed, 10 Aug 2016 20:09:21 GMT"
+    `;
+
+    vi.mocked($fetch).mockResolvedValueOnce(mockTimemapResponse);
+
+    const archive = createArchiveClient(createArchiveToday());
+    const result = await archive.snapshots("example.com");
+
+    expect(result.success).toBe(true);
+    expect(result.pages.map((page) => page._meta.hash)).toEqual([
+      "20020120142510",
+      "20140101030405",
+      "20160810200921",
+    ]);
+  });
+
+  it("parses a single-capture timemap labeled first last memento", async () => {
+    const mockTimemapResponse = `
+    <http://archive.md/20160810200921/https://example.com/>; rel="first last memento"; datetime="Wed, 10 Aug 2016 20:09:21 GMT"
+    `;
+
+    vi.mocked($fetch).mockResolvedValueOnce(mockTimemapResponse);
+
+    const archive = createArchiveClient(createArchiveToday());
+    const result = await archive.snapshots("example.com");
+
+    expect(result.success).toBe(true);
+    expect(result.pages).toHaveLength(1);
+    expect(result.pages[0]._meta.hash).toBe("20160810200921");
+  });
+
   it("returns an error response when the Memento API fails", async () => {
     vi.mocked($fetch).mockRejectedValueOnce(new Error("API error"));
 


### PR DESCRIPTION
Archive.today ends its timemap with a row labeled `rel="last memento"` and the regex only accepted `memento` and `first memento`, so every listing silently lost its newest capture. Worst possible row to lose. Checked against the live timemap for example.com: 1136 memento rows, the old regex matches 1135. A lone `rel="first last memento"` capture parses now too.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/agntn/archives/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

