### PR TITLE
fix: treat the Common Crawl no-captures 404 as empty

### DIFF
--- a/src/providers/commoncrawl.ts
+++ b/src/providers/commoncrawl.ts
@@ -103,7 +103,13 @@ export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
         timeout: options.timeout ?? 60_000,
         responseType: "text",
       });
-      const raw = await $fetch(`/${index.indexName}`, fetchOptions);
+      let raw: unknown;
+      try {
+        raw = await $fetch(`/${index.indexName}`, fetchOptions);
+      } catch (error) {
+        if (!isNoCapturesError(error)) throw error;
+        raw = "";
+      }
       const records = parseIndexRecords(raw);
 
       if (records.length === 0) {
@@ -317,7 +323,13 @@ export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
       timeout: options.timeout ?? 60_000,
       responseType: "text",
     });
-    const raw = await $fetch(`/${indexName}`, fetchOptions);
+    let raw: unknown;
+    try {
+      raw = await $fetch(`/${indexName}`, fetchOptions);
+    } catch (error) {
+      if (!isNoCapturesError(error)) throw error;
+      raw = "";
+    }
 
     const captures: CrawlCapture[] = [];
     for (const record of parseIndexRecords(raw)) {
@@ -403,6 +415,24 @@ export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
       ...(contentType ? { mime: contentType.split(";")[0]?.trim().toLowerCase() } : {}),
     };
   }
+}
+
+/**
+ * Whether a thrown index error is the CDX way of saying the URL was never
+ * captured: the endpoint answers 404 with a JSON `No Captures found` message
+ * instead of an empty body, so a missing page would otherwise read as an
+ * outage. Every other 404 keeps meaning failure.
+ */
+function isNoCapturesError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const { status, statusCode, data } = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    data?: unknown;
+  };
+  if (status !== 404 && statusCode !== 404) return false;
+  const body = typeof data === "string" ? data : data ? JSON.stringify(data) : "";
+  return body.includes("No Captures found");
 }
 
 /** Parses the newline-delimited JSON the CDX index answers with. */

--- a/test/commoncrawl.test.ts
+++ b/test/commoncrawl.test.ts
@@ -100,6 +100,37 @@ describe("Common Crawl", () => {
     expect(result._meta?.source).toBe("commoncrawl");
   });
 
+  it("treats the no-captures 404 as an empty result", async () => {
+    const collInfo = [{ name: "CC-MAIN-2023-50" }];
+    const noCaptures = Object.assign(new Error("404 Not Found"), {
+      statusCode: 404,
+      data: '{"message": "No Captures found for: definitely-not-real.example/"}',
+    });
+    vi.mocked($fetch).mockResolvedValueOnce(collInfo).mockRejectedValueOnce(noCaptures);
+
+    const archive = createArchive(createCommonCrawl());
+    const result = await archive.snapshots("definitely-not-real.example");
+
+    expect(result.success).toBe(true);
+    expect(result.pages).toHaveLength(0);
+    expect(result._meta?.collection).toBe("CC-MAIN-2023-50");
+  });
+
+  it("keeps other 404 responses as errors", async () => {
+    const missingIndex = Object.assign(new Error("404 Not Found"), {
+      statusCode: 404,
+      data: "Not Found",
+    });
+    vi.mocked($fetch).mockRejectedValueOnce(missingIndex);
+
+    const options: CommonCrawlOptions = { collection: "CC-MAIN-2019-04" };
+    const archive = createArchive(createCommonCrawl());
+    const result = await archive.snapshots("example.com", options);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("404 Not Found");
+  });
+
   it("drops records with malformed timestamps", async () => {
     const records = [
       {

--- a/test/content.test.ts
+++ b/test/content.test.ts
@@ -478,6 +478,21 @@ describe("common crawl content", () => {
     });
   });
 
+  it("reports the missing capture when the index answers no-captures", async () => {
+    const noCaptures = Object.assign(new Error("404 Not Found"), {
+      statusCode: 404,
+      data: '{"message": "No Captures found for: example.com/"}',
+    });
+    fetchMock.mockRejectedValueOnce(noCaptures);
+
+    const response = await createArchive(
+      createCommonCrawl({ collection: "CC-MAIN-2024-10" }),
+    ).content("example.com");
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("No Common Crawl capture for");
+  });
+
   it("bounds the index query around the requested instant", async () => {
     fetchMock
       .mockResolvedValueOnce(


### PR DESCRIPTION
A domain Common Crawl never crawled is not an outage, but `snapshots()` reported one, because the live CDX answers no captures with a 404 `No Captures found` JSON instead of an empty body. That answer counts as an empty listing now, on the content path too. Any other 404 still fails.

Closes #38

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/agntn/archives/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

