### PR TITLE
perf: stop resolving typebox at every spawn

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -11,4 +11,16 @@ export default defineBuildConfig({
       input: ["./src/index.ts", "./src/cli.ts", "./src/mcp.ts", "./src/tool-operations.ts"],
     },
   ],
+  hooks: {
+    // typebox stays inline: resolving and parsing it from node_modules costs the
+    // MCP server more at every spawn than the bundled copy does. obuild marks
+    // every dependency and peer dependency external, so the entries the default
+    // adds for typebox are filtered back out here.
+    rolldownConfig(config) {
+      const externals = Array.isArray(config.external) ? config.external : [];
+      config.external = externals.filter(
+        (entry) => entry !== "typebox" && !(entry instanceof RegExp && entry.test("typebox/value")),
+      );
+    },
+  },
 });


### PR DESCRIPTION
Most of the MCP startup was node_modules resolution for `typebox`, not archives code. With the bundled copy handshake medians went from 389 ms to 240 ms here, interleaved runs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/agntn/archives/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

