### PR TITLE
ci: publish tagged releases through OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - run: pnpm install
+      - run: pnpm test
+      - run: npm publish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ archives/
 - **The library decodes, a surface renders**: charset decoding, WARC unwrapping and transfer/content encodings are library work, and the body it returns is text; `htmlToText`, clipping to `maxChars` and the untrusted-data fence are applied in `tool-operations.ts`, so a library consumer keeps the whole document rather than a reader's view of it. Text is the contract, not the raw bytes: a capture that is not text decodes lossily and its bytes stay behind `_meta.rawSnapshot` or the WARC coordinates.
 - **The MCP process does not trust its own cwd**: `src/commands/mcp.ts` calls `setConfigCwd(homedir())` because a client spawns the server in an arbitrary checkout, and c12 executes the `archives.config.ts` it finds. `consola.level` is pinned there too — stdout carries the JSON-RPC frames.
 - **Pi extension packaging**: distributable extension lives under `packages/pi/extensions/*.ts`; `package.json` `pi.extensions` points there and `files` includes the directory.
-- **Release**: `pnpm test && changelogen --release --push && pnpm publish`.
+- **Release**: `pnpm test && changelogen --release --push`; the pushed `v*` tag triggers `.github/workflows/publish.yml`, which publishes to npm through OIDC.
 
 ## ANTI-PATTERNS (THIS PROJECT)
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
   ],
   "type": "module",
   "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -69,7 +72,7 @@
     "test:types": "pnpm build && tsc --noEmit --skipLibCheck && tsc --noEmit --skipLibCheck -p tsconfig.extensions.json",
     "build": "obuild",
     "prepack": "pnpm build",
-    "release": "pnpm test && changelogen --release --push && pnpm publish"
+    "release": "pnpm test && changelogen --release --push"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.30.0",


### PR DESCRIPTION
`pnpm release` was publishing from the local machine after pushing the tag. That is the wrong place for registry credentials, so tagged CI owns publication through OIDC now. npm still needs `publish.yml` selected as the Trusted Publisher if it is not configured yet.