### PR TITLE
feat: keep numeric limits visible to agents

### DIFF
--- a/packages/omp/extensions/archives.ts
+++ b/packages/omp/extensions/archives.ts
@@ -107,7 +107,7 @@ function buildParameterSchemas({ Type }: ExtensionAPI["typebox"]) {
     ),
     limit: Type.Optional(
       Type.Integer({
-        description: `Maximum snapshots to return. Defaults to ${DEFAULT_LIMIT}.`,
+        description: `Maximum snapshots to return. Defaults to ${DEFAULT_LIMIT}; accepted range: 1-${MAX_LIMIT}.`,
         minimum: 1,
         maximum: MAX_LIMIT,
       }),
@@ -116,28 +116,36 @@ function buildParameterSchemas({ Type }: ExtensionAPI["typebox"]) {
       Type.Boolean({ description: "Enable or disable archives response caching." }),
     ),
     ttl: Type.Optional(
-      Type.Integer({ description: "Cache TTL in milliseconds.", minimum: 0, maximum: MAX_TTL }),
+      Type.Integer({
+        description: `Cache TTL in milliseconds; accepted range: 0-${MAX_TTL}.`,
+        minimum: 0,
+        maximum: MAX_TTL,
+      }),
     ),
     concurrency: Type.Optional(
-      Type.Integer({ description: "Maximum parallel provider requests.", minimum: 1, maximum: 10 }),
+      Type.Integer({
+        description: "Maximum parallel provider requests; accepted range: 1-10.",
+        minimum: 1,
+        maximum: 10,
+      }),
     ),
     batchSize: Type.Optional(
       Type.Integer({
-        description: "Provider batch size for parallel work.",
+        description: "Provider batch size for parallel work; accepted range: 1-100.",
         minimum: 1,
         maximum: 100,
       }),
     ),
     timeout: Type.Optional(
       Type.Integer({
-        description: "Request timeout in milliseconds.",
+        description: `Request timeout in milliseconds; accepted range: 1-${MAX_TIMEOUT}.`,
         minimum: 1,
         maximum: MAX_TIMEOUT,
       }),
     ),
     retries: Type.Optional(
       Type.Integer({
-        description: "Retry attempts for failed requests.",
+        description: `Retry attempts for failed requests; accepted range: 0-${MAX_RETRIES}.`,
         minimum: 0,
         maximum: MAX_RETRIES,
       }),
@@ -215,7 +223,7 @@ function buildParameterSchemas({ Type }: ExtensionAPI["typebox"]) {
     ),
     maxChars: Type.Optional(
       Type.Integer({
-        description: `Maximum characters of body to return. Defaults to ${DEFAULT_MAX_CHARS}.`,
+        description: `Maximum characters of body to return. Defaults to ${DEFAULT_MAX_CHARS}; accepted range: 1-${MAX_CONTENT_CHARS}.`,
         minimum: 1,
         maximum: MAX_CONTENT_CHARS,
       }),
@@ -224,18 +232,22 @@ function buildParameterSchemas({ Type }: ExtensionAPI["typebox"]) {
       Type.Boolean({ description: "Enable or disable archives response caching." }),
     ),
     ttl: Type.Optional(
-      Type.Integer({ description: "Cache TTL in milliseconds.", minimum: 0, maximum: MAX_TTL }),
+      Type.Integer({
+        description: `Cache TTL in milliseconds; accepted range: 0-${MAX_TTL}.`,
+        minimum: 0,
+        maximum: MAX_TTL,
+      }),
     ),
     timeout: Type.Optional(
       Type.Integer({
-        description: `Request timeout in milliseconds. Defaults to ${DEFAULT_CONTENT_TIMEOUT}.`,
+        description: `Request timeout in milliseconds. Defaults to ${DEFAULT_CONTENT_TIMEOUT}; accepted range: 1-${MAX_TIMEOUT}.`,
         minimum: 1,
         maximum: MAX_TIMEOUT,
       }),
     ),
     retries: Type.Optional(
       Type.Integer({
-        description: "Retry attempts for failed requests.",
+        description: `Retry attempts for failed requests; accepted range: 0-${MAX_RETRIES}.`,
         minimum: 0,
         maximum: MAX_RETRIES,
       }),

--- a/packages/pi/extensions/archives.ts
+++ b/packages/pi/extensions/archives.ts
@@ -103,7 +103,7 @@ const snapshotParameters = Type.Object({
   ),
   limit: Type.Optional(
     Type.Integer({
-      description: `Maximum snapshots to return. Defaults to ${DEFAULT_LIMIT}.`,
+      description: `Maximum snapshots to return. Defaults to ${DEFAULT_LIMIT}; accepted range: 1-${MAX_LIMIT}.`,
       minimum: 1,
       maximum: MAX_LIMIT,
     }),
@@ -112,28 +112,36 @@ const snapshotParameters = Type.Object({
     Type.Boolean({ description: "Enable or disable archives response caching." }),
   ),
   ttl: Type.Optional(
-    Type.Integer({ description: "Cache TTL in milliseconds.", minimum: 0, maximum: MAX_TTL }),
+    Type.Integer({
+      description: `Cache TTL in milliseconds; accepted range: 0-${MAX_TTL}.`,
+      minimum: 0,
+      maximum: MAX_TTL,
+    }),
   ),
   concurrency: Type.Optional(
-    Type.Integer({ description: "Maximum parallel provider requests.", minimum: 1, maximum: 10 }),
+    Type.Integer({
+      description: "Maximum parallel provider requests; accepted range: 1-10.",
+      minimum: 1,
+      maximum: 10,
+    }),
   ),
   batchSize: Type.Optional(
     Type.Integer({
-      description: "Provider batch size for parallel work.",
+      description: "Provider batch size for parallel work; accepted range: 1-100.",
       minimum: 1,
       maximum: 100,
     }),
   ),
   timeout: Type.Optional(
     Type.Integer({
-      description: "Request timeout in milliseconds.",
+      description: `Request timeout in milliseconds; accepted range: 1-${MAX_TIMEOUT}.`,
       minimum: 1,
       maximum: MAX_TIMEOUT,
     }),
   ),
   retries: Type.Optional(
     Type.Integer({
-      description: "Retry attempts for failed requests.",
+      description: `Retry attempts for failed requests; accepted range: 0-${MAX_RETRIES}.`,
       minimum: 0,
       maximum: MAX_RETRIES,
     }),
@@ -211,7 +219,7 @@ const contentParameters = Type.Object({
   ),
   maxChars: Type.Optional(
     Type.Integer({
-      description: `Maximum characters of body to return. Defaults to ${DEFAULT_MAX_CHARS}.`,
+      description: `Maximum characters of body to return. Defaults to ${DEFAULT_MAX_CHARS}; accepted range: 1-${MAX_CONTENT_CHARS}.`,
       minimum: 1,
       maximum: MAX_CONTENT_CHARS,
     }),
@@ -220,18 +228,22 @@ const contentParameters = Type.Object({
     Type.Boolean({ description: "Enable or disable archives response caching." }),
   ),
   ttl: Type.Optional(
-    Type.Integer({ description: "Cache TTL in milliseconds.", minimum: 0, maximum: MAX_TTL }),
+    Type.Integer({
+      description: `Cache TTL in milliseconds; accepted range: 0-${MAX_TTL}.`,
+      minimum: 0,
+      maximum: MAX_TTL,
+    }),
   ),
   timeout: Type.Optional(
     Type.Integer({
-      description: `Request timeout in milliseconds. Defaults to ${DEFAULT_CONTENT_TIMEOUT}.`,
+      description: `Request timeout in milliseconds. Defaults to ${DEFAULT_CONTENT_TIMEOUT}; accepted range: 1-${MAX_TIMEOUT}.`,
       minimum: 1,
       maximum: MAX_TIMEOUT,
     }),
   ),
   retries: Type.Optional(
     Type.Integer({
-      description: "Retry attempts for failed requests.",
+      description: `Retry attempts for failed requests; accepted range: 0-${MAX_RETRIES}.`,
       minimum: 0,
       maximum: MAX_RETRIES,
     }),

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -71,7 +71,7 @@ const tools: ToolDefinition[] = [
         ),
         limit: Type.Optional(
           Type.Integer({
-            description: `Maximum snapshots to return. Defaults to ${DEFAULT_LIMIT}.`,
+            description: `Maximum snapshots to return. Defaults to ${DEFAULT_LIMIT}; accepted range: 1-${MAX_LIMIT}.`,
             minimum: 1,
             maximum: MAX_LIMIT,
           }),
@@ -80,32 +80,36 @@ const tools: ToolDefinition[] = [
           Type.Boolean({ description: "Enable or disable archives response caching." }),
         ),
         ttl: Type.Optional(
-          Type.Integer({ description: "Cache TTL in milliseconds.", minimum: 0, maximum: MAX_TTL }),
+          Type.Integer({
+            description: `Cache TTL in milliseconds; accepted range: 0-${MAX_TTL}.`,
+            minimum: 0,
+            maximum: MAX_TTL,
+          }),
         ),
         concurrency: Type.Optional(
           Type.Integer({
-            description: "Maximum parallel provider requests.",
+            description: "Maximum parallel provider requests; accepted range: 1-10.",
             minimum: 1,
             maximum: 10,
           }),
         ),
         batchSize: Type.Optional(
           Type.Integer({
-            description: "Provider batch size for parallel work.",
+            description: "Provider batch size for parallel work; accepted range: 1-100.",
             minimum: 1,
             maximum: 100,
           }),
         ),
         timeout: Type.Optional(
           Type.Integer({
-            description: "Request timeout in milliseconds.",
+            description: `Request timeout in milliseconds; accepted range: 1-${MAX_TIMEOUT}.`,
             minimum: 1,
             maximum: MAX_TIMEOUT,
           }),
         ),
         retries: Type.Optional(
           Type.Integer({
-            description: "Retry attempts for failed requests.",
+            description: `Retry attempts for failed requests; accepted range: 0-${MAX_RETRIES}.`,
             minimum: 0,
             maximum: MAX_RETRIES,
           }),
@@ -203,7 +207,7 @@ const tools: ToolDefinition[] = [
         ),
         maxChars: Type.Optional(
           Type.Integer({
-            description: `Maximum characters of body to return. Defaults to ${DEFAULT_MAX_CHARS}.`,
+            description: `Maximum characters of body to return. Defaults to ${DEFAULT_MAX_CHARS}; accepted range: 1-${MAX_CONTENT_CHARS}.`,
             minimum: 1,
             maximum: MAX_CONTENT_CHARS,
           }),
@@ -212,18 +216,22 @@ const tools: ToolDefinition[] = [
           Type.Boolean({ description: "Enable or disable archives response caching." }),
         ),
         ttl: Type.Optional(
-          Type.Integer({ description: "Cache TTL in milliseconds.", minimum: 0, maximum: MAX_TTL }),
+          Type.Integer({
+            description: `Cache TTL in milliseconds; accepted range: 0-${MAX_TTL}.`,
+            minimum: 0,
+            maximum: MAX_TTL,
+          }),
         ),
         timeout: Type.Optional(
           Type.Integer({
-            description: `Request timeout in milliseconds. Defaults to ${DEFAULT_CONTENT_TIMEOUT}.`,
+            description: `Request timeout in milliseconds. Defaults to ${DEFAULT_CONTENT_TIMEOUT}; accepted range: 1-${MAX_TIMEOUT}.`,
             minimum: 1,
             maximum: MAX_TIMEOUT,
           }),
         ),
         retries: Type.Optional(
           Type.Integer({
-            description: "Retry attempts for failed requests.",
+            description: `Retry attempts for failed requests; accepted range: 0-${MAX_RETRIES}.`,
             minimum: 0,
             maximum: MAX_RETRIES,
           }),

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -140,6 +140,27 @@ describe("archives MCP server", () => {
     });
   });
 
+  it("keeps numeric bounds visible in parameter descriptions", async () => {
+    const client = await connectTestClient();
+    const response = await client.listTools();
+
+    for (const [toolName, parameterNames] of [
+      ["archives_snapshots", ["limit", "ttl", "concurrency", "batchSize", "timeout", "retries"]],
+      ["archives_content", ["maxChars", "ttl", "timeout", "retries"]],
+    ] as const) {
+      const tool = response.tools.find((candidate) => candidate.name === toolName);
+      if (!tool) throw new Error(`Tool not registered: ${toolName}`);
+      const properties = tool.inputSchema.properties as Record<string, Record<string, unknown>>;
+
+      for (const parameterName of parameterNames) {
+        const parameter = properties[parameterName];
+        expect(parameter?.["description"]).toContain(
+          `accepted range: ${parameter?.["minimum"]}-${parameter?.["maximum"]}`,
+        );
+      }
+    }
+  });
+
   it("lists providers and flags Perma.cc as unconfigured without an API key", async () => {
     const client = await connectTestClient();
 

--- a/test/omp-extension.test.ts
+++ b/test/omp-extension.test.ts
@@ -75,7 +75,16 @@ describe("archives OMP extension", () => {
 
   it("declares the content bounds the shared executors enforce", () => {
     const tool = requireTool(registerExtension().tools, "archives_content");
+    const properties = (tool.parameters as unknown as TypeBox.TSchema).toJsonSchema()[
+      "properties"
+    ] as Record<string, Record<string, unknown>>;
 
+    for (const parameterName of ["maxChars", "ttl", "timeout", "retries"]) {
+      const parameter = properties[parameterName];
+      expect(parameter?.["description"]).toContain(
+        `accepted range: ${parameter?.["minimum"]}-${parameter?.["maximum"]}`,
+      );
+    }
     expect(accepts(tool, { target: "example.com" })).toBe(true);
     expect(accepts(tool, { target: "example.com", format: "text" })).toBe(true);
     expect(accepts(tool, { target: "example.com", format: "raw" })).toBe(true);
@@ -102,9 +111,25 @@ describe("archives OMP extension", () => {
 
   it("bounds limit where the shared executors reject it", () => {
     const tool = requireTool(registerExtension().tools, "archives");
+    const properties = (tool.parameters as unknown as TypeBox.TSchema).toJsonSchema()[
+      "properties"
+    ] as Record<string, Record<string, unknown>>;
 
     // The parameters are declared before the executors can be loaded, so the
     // restated bound has to match what src/tool-operations actually enforces.
+    for (const parameterName of [
+      "limit",
+      "ttl",
+      "concurrency",
+      "batchSize",
+      "timeout",
+      "retries",
+    ]) {
+      const parameter = properties[parameterName];
+      expect(parameter?.["description"]).toContain(
+        `accepted range: ${parameter?.["minimum"]}-${parameter?.["maximum"]}`,
+      );
+    }
     expect(accepts(tool, { target: "example.com", limit: MAX_LIMIT })).toBe(true);
     expect(accepts(tool, { target: "example.com", limit: MAX_LIMIT + 1 })).toBe(false);
     for (const provider of PROVIDER_INPUTS) {

--- a/test/pi-extension.test.ts
+++ b/test/pi-extension.test.ts
@@ -167,7 +167,13 @@ describe("Pi extension", () => {
       minimum: 1,
       maximum: MAX_CONTENT_CHARS,
     });
-    expect(properties["maxChars"]?.["description"]).toContain(`Defaults to ${DEFAULT_MAX_CHARS}.`);
+    expect(properties["maxChars"]?.["description"]).toContain(`Defaults to ${DEFAULT_MAX_CHARS}`);
+    for (const parameterName of ["maxChars", "ttl", "timeout", "retries"]) {
+      const parameter = properties[parameterName];
+      expect(parameter?.["description"]).toContain(
+        `accepted range: ${parameter?.["minimum"]}-${parameter?.["maximum"]}`,
+      );
+    }
 
     const offeredFormats = (
       (properties["format"]?.["anyOf"] ?? []) as Array<{ const: string }>
@@ -282,7 +288,20 @@ describe("Pi extension", () => {
     // The parameters are declared before the executors can be loaded, so the
     // restated metadata has to match what src/tool-operations actually applies.
     expect(properties["limit"]).toMatchObject({ minimum: 1, maximum: MAX_LIMIT });
-    expect(properties["limit"]?.["description"]).toContain(`Defaults to ${DEFAULT_LIMIT}.`);
+    expect(properties["limit"]?.["description"]).toContain(`Defaults to ${DEFAULT_LIMIT}`);
+    for (const parameterName of [
+      "limit",
+      "ttl",
+      "concurrency",
+      "batchSize",
+      "timeout",
+      "retries",
+    ]) {
+      const parameter = properties[parameterName];
+      expect(parameter?.["description"]).toContain(
+        `accepted range: ${parameter?.["minimum"]}-${parameter?.["maximum"]}`,
+      );
+    }
     expect(properties["provider"]?.["description"]).toBe(PROVIDER_HINT);
     expect(properties["from"]?.["description"]).toBe(SNAPSHOT_FROM_HINT);
     expect(properties["to"]?.["description"]).toBe(SNAPSHOT_TO_HINT);


### PR DESCRIPTION
Flattened tool catalogs made `limit: 1000` look valid even though the server rejects anything above 100. The accepted ranges live in parameter descriptions now, with the same contract across MCP, Pi, and OMP.

Closes #45